### PR TITLE
chore: swap truncate and ttl arguments

### DIFF
--- a/integration/dictionary.test.ts
+++ b/integration/dictionary.test.ts
@@ -590,7 +590,7 @@ describe('Integration tests for dictionary operations', () => {
         props.dictionaryName,
         props.field,
         5,
-        props.ttl
+        {ttl: props.ttl}
       );
     };
 
@@ -1043,7 +1043,7 @@ describe('Integration tests for dictionary operations', () => {
         props.dictionaryName,
         props.field,
         props.value,
-        props.ttl
+        {ttl: props.ttl}
       );
     };
 
@@ -1131,7 +1131,7 @@ describe('Integration tests for dictionary operations', () => {
         props.cacheName,
         props.dictionaryName,
         new Map([[props.field, props.value]]),
-        props.ttl
+        {ttl: props.ttl}
       );
     };
 
@@ -1151,7 +1151,7 @@ describe('Integration tests for dictionary operations', () => {
           [field1, value1],
           [field2, value2],
         ]),
-        CollectionTtl.of(10)
+        {ttl: CollectionTtl.of(10)}
       );
       expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
       let getResponse = await Momento.dictionaryGetField(
@@ -1187,7 +1187,7 @@ describe('Integration tests for dictionary operations', () => {
           [field1, value1],
           [field2, value2],
         ]),
-        CollectionTtl.of(10)
+        {ttl: CollectionTtl.of(10)}
       );
       expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
       let getResponse = await Momento.dictionaryGetField(
@@ -1220,7 +1220,7 @@ describe('Integration tests for dictionary operations', () => {
         IntegrationTestCacheName,
         dictionaryName,
         {foo: value1, bar: value2},
-        CollectionTtl.of(10)
+        {ttl: CollectionTtl.of(10)}
       );
       expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
       let getResponse = await Momento.dictionaryGetField(
@@ -1256,7 +1256,7 @@ describe('Integration tests for dictionary operations', () => {
           [field1, value1],
           [field2, value2],
         ]),
-        CollectionTtl.of(10)
+        {ttl: CollectionTtl.of(10)}
       );
       expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
       let getResponse = await Momento.dictionaryGetField(
@@ -1290,7 +1290,7 @@ describe('Integration tests for dictionary operations', () => {
         IntegrationTestCacheName,
         dictionaryName,
         {foo: textEncoder.encode(value1), bar: textEncoder.encode(value2)},
-        CollectionTtl.of(10)
+        {ttl: CollectionTtl.of(10)}
       );
       expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
       let getResponse = await Momento.dictionaryGetField(

--- a/integration/list.test.ts
+++ b/integration/list.test.ts
@@ -365,8 +365,8 @@ describe('lists', () => {
         props.cacheName,
         props.listName,
         props.value,
-        props.ttl,
-        props.truncateToSize
+        props.truncateToSize,
+        props.ttl
       );
     });
 
@@ -390,8 +390,8 @@ describe('lists', () => {
         props.cacheName,
         props.listName,
         props.value,
-        props.ttl,
-        props.truncateToSize
+        props.truncateToSize,
+        props.ttl
       );
     });
 
@@ -457,8 +457,8 @@ describe('lists', () => {
         props.cacheName,
         props.listName,
         [props.value] as string[] | Uint8Array[],
-        props.ttl,
-        props.truncateToSize
+        props.truncateToSize,
+        props.ttl
       );
     });
 
@@ -512,8 +512,8 @@ describe('lists', () => {
         props.cacheName,
         props.listName,
         [props.value] as string[] | Uint8Array[],
-        props.ttl,
-        props.truncateToSize
+        props.truncateToSize,
+        props.ttl
       );
     });
 

--- a/integration/list.test.ts
+++ b/integration/list.test.ts
@@ -365,8 +365,10 @@ describe('lists', () => {
         props.cacheName,
         props.listName,
         props.value,
-        props.truncateToSize,
-        props.ttl
+        {
+          truncateFrontToSize: props.truncateToSize,
+          ttl: props.ttl,
+        }
       );
     });
 
@@ -390,8 +392,10 @@ describe('lists', () => {
         props.cacheName,
         props.listName,
         props.value,
-        props.truncateToSize,
-        props.ttl
+        {
+          truncateBackToSize: props.truncateToSize,
+          ttl: props.ttl,
+        }
       );
     });
 
@@ -457,8 +461,10 @@ describe('lists', () => {
         props.cacheName,
         props.listName,
         [props.value] as string[] | Uint8Array[],
-        props.truncateToSize,
-        props.ttl
+        {
+          truncateFrontToSize: props.truncateToSize,
+          ttl: props.ttl,
+        }
       );
     });
 
@@ -512,8 +518,10 @@ describe('lists', () => {
         props.cacheName,
         props.listName,
         [props.value] as string[] | Uint8Array[],
-        props.truncateToSize,
-        props.ttl
+        {
+          truncateBackToSize: props.truncateToSize,
+          ttl: props.ttl,
+        }
       );
     });
 

--- a/integration/set.test.ts
+++ b/integration/set.test.ts
@@ -173,7 +173,7 @@ describe('Integration Tests for operations on sets datastructure', () => {
       IntegrationTestCacheName,
       setName,
       [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
-      new CollectionTtl(2, false)
+      {ttl: new CollectionTtl(2, false)}
     );
     expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
 
@@ -181,7 +181,7 @@ describe('Integration Tests for operations on sets datastructure', () => {
       IntegrationTestCacheName,
       setName,
       [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
-      new CollectionTtl(10, false)
+      {ttl: new CollectionTtl(10, false)}
     );
     expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
 
@@ -199,7 +199,7 @@ describe('Integration Tests for operations on sets datastructure', () => {
       IntegrationTestCacheName,
       setName,
       [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
-      new CollectionTtl(2, false)
+      {ttl: new CollectionTtl(2, false)}
     );
     expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
 
@@ -207,7 +207,7 @@ describe('Integration Tests for operations on sets datastructure', () => {
       IntegrationTestCacheName,
       setName,
       [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
-      new CollectionTtl(10, true)
+      {ttl: new CollectionTtl(10, true)}
     );
     expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
 

--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -225,7 +225,7 @@ export class CacheClient {
     cacheName: string,
     setName: string,
     elements: string[] | Uint8Array[],
-    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheSetAddElements.Response> {
     try {
       validateCacheName(cacheName);
@@ -237,8 +237,8 @@ export class CacheClient {
       cacheName,
       this.convert(setName),
       this.convertArray(elements),
-      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      collectionTtl.refreshTtl()
+      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      ttl.refreshTtl()
     );
   }
 
@@ -436,7 +436,7 @@ export class CacheClient {
     listName: string,
     values: string[] | Uint8Array[],
     truncateFrontToSize?: number,
-    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheListConcatenateBack.Response> {
     try {
       validateCacheName(cacheName);
@@ -450,7 +450,7 @@ export class CacheClient {
     this.logger.trace(
       `Issuing 'listConcatenateBack' request; listName: ${listName}, values length: ${
         values.length
-      }, ${collectionTtl.toString()}, truncateFrontToSize: ${
+      }, ${ttl.toString()}, truncateFrontToSize: ${
         truncateFrontToSize?.toString() ?? 'null'
       }`
     );
@@ -459,8 +459,8 @@ export class CacheClient {
       cacheName,
       this.convert(listName),
       this.convertArray(values),
-      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      collectionTtl.refreshTtl(),
+      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      ttl.refreshTtl(),
       truncateFrontToSize
     );
     this.logger.trace(
@@ -510,7 +510,7 @@ export class CacheClient {
     listName: string,
     values: string[] | Uint8Array[],
     truncateBackToSize?: number,
-    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheListConcatenateFront.Response> {
     try {
       validateCacheName(cacheName);
@@ -524,7 +524,7 @@ export class CacheClient {
     this.logger.trace(
       `Issuing 'listConcatenateFront' request; listName: ${listName}, values length: ${
         values.length
-      }, ${collectionTtl.toString()}, truncateBackToSize: ${
+      }, ${ttl.toString()}, truncateBackToSize: ${
         truncateBackToSize?.toString() ?? 'null'
       }`
     );
@@ -533,8 +533,8 @@ export class CacheClient {
       cacheName,
       this.convert(listName),
       this.convertArray(values),
-      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      collectionTtl.refreshTtl(),
+      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      ttl.refreshTtl(),
       truncateBackToSize
     );
     this.logger.trace(
@@ -778,7 +778,7 @@ export class CacheClient {
     listName: string,
     value: string | Uint8Array,
     truncateFrontToSize?: number,
-    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheListPushBack.Response> {
     try {
       validateCacheName(cacheName);
@@ -790,7 +790,7 @@ export class CacheClient {
     this.logger.trace(
       `Issuing 'listPushBack' request; listName: ${listName}, value length: ${
         value.length
-      }, ${collectionTtl.toString()}, truncateFrontToSize: ${
+      }, ${ttl.toString()}, truncateFrontToSize: ${
         truncateFrontToSize?.toString() ?? 'null'
       }`
     );
@@ -799,8 +799,8 @@ export class CacheClient {
       cacheName,
       this.convert(listName),
       this.convert(value),
-      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      collectionTtl.refreshTtl(),
+      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      ttl.refreshTtl(),
       truncateFrontToSize
     );
     this.logger.trace(`'listPushBack' request result: ${result.toString()}`);
@@ -846,7 +846,7 @@ export class CacheClient {
     listName: string,
     value: string | Uint8Array,
     truncateBackToSize?: number,
-    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheListPushFront.Response> {
     try {
       validateCacheName(cacheName);
@@ -858,7 +858,7 @@ export class CacheClient {
     this.logger.trace(
       `Issuing 'listPushFront' request; listName: ${listName}, value length: ${
         value.length
-      }, ${collectionTtl.toString()}, truncateBackToSize: ${
+      }, ${ttl.toString()}, truncateBackToSize: ${
         truncateBackToSize?.toString() ?? 'null'
       }`
     );
@@ -867,8 +867,8 @@ export class CacheClient {
       cacheName,
       this.convert(listName),
       this.convert(value),
-      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      collectionTtl.refreshTtl(),
+      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      ttl.refreshTtl(),
       truncateBackToSize
     );
     this.logger.trace(`'listPushFront' request result: ${result.toString()}`);
@@ -1089,7 +1089,7 @@ export class CacheClient {
     items:
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>,
-    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheDictionarySetFields.Response> {
     try {
       validateCacheName(cacheName);
@@ -1101,7 +1101,7 @@ export class CacheClient {
     }
     this.logger.trace(
       `Issuing 'dictionarySetFields' request; items: ${items.toString()}, ttl: ${
-        collectionTtl.ttlSeconds.toString() ?? 'null'
+        ttl.ttlSeconds.toString() ?? 'null'
       }`
     );
 
@@ -1111,8 +1111,8 @@ export class CacheClient {
       cacheName,
       this.convert(dictionaryName),
       dictionaryFieldValuePairs,
-      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      collectionTtl.refreshTtl()
+      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      ttl.refreshTtl()
     );
     this.logger.trace(
       `'dictionarySetFields' request result: ${result.toString()}`

--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -225,7 +225,7 @@ export class CacheClient {
     cacheName: string,
     setName: string,
     elements: string[] | Uint8Array[],
-    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheSetAddElements.Response> {
     try {
       validateCacheName(cacheName);
@@ -237,8 +237,8 @@ export class CacheClient {
       cacheName,
       this.convert(setName),
       this.convertArray(elements),
-      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      ttl.refreshTtl()
+      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      collectionTtl.refreshTtl()
     );
   }
 
@@ -435,8 +435,8 @@ export class CacheClient {
     cacheName: string,
     listName: string,
     values: string[] | Uint8Array[],
-    ttl: CollectionTtl = CollectionTtl.fromCacheTtl(),
-    truncateFrontToSize?: number
+    truncateFrontToSize?: number,
+    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheListConcatenateBack.Response> {
     try {
       validateCacheName(cacheName);
@@ -450,7 +450,7 @@ export class CacheClient {
     this.logger.trace(
       `Issuing 'listConcatenateBack' request; listName: ${listName}, values length: ${
         values.length
-      }, ${ttl.toString()}, truncateFrontToSize: ${
+      }, ${collectionTtl.toString()}, truncateFrontToSize: ${
         truncateFrontToSize?.toString() ?? 'null'
       }`
     );
@@ -459,8 +459,8 @@ export class CacheClient {
       cacheName,
       this.convert(listName),
       this.convertArray(values),
-      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      ttl.refreshTtl(),
+      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      collectionTtl.refreshTtl(),
       truncateFrontToSize
     );
     this.logger.trace(
@@ -509,8 +509,8 @@ export class CacheClient {
     cacheName: string,
     listName: string,
     values: string[] | Uint8Array[],
-    ttl: CollectionTtl = CollectionTtl.fromCacheTtl(),
-    truncateBackToSize?: number
+    truncateBackToSize?: number,
+    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheListConcatenateFront.Response> {
     try {
       validateCacheName(cacheName);
@@ -524,7 +524,7 @@ export class CacheClient {
     this.logger.trace(
       `Issuing 'listConcatenateFront' request; listName: ${listName}, values length: ${
         values.length
-      }, ${ttl.toString()}, truncateBackToSize: ${
+      }, ${collectionTtl.toString()}, truncateBackToSize: ${
         truncateBackToSize?.toString() ?? 'null'
       }`
     );
@@ -533,8 +533,8 @@ export class CacheClient {
       cacheName,
       this.convert(listName),
       this.convertArray(values),
-      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      ttl.refreshTtl(),
+      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      collectionTtl.refreshTtl(),
       truncateBackToSize
     );
     this.logger.trace(
@@ -777,8 +777,8 @@ export class CacheClient {
     cacheName: string,
     listName: string,
     value: string | Uint8Array,
-    ttl: CollectionTtl = CollectionTtl.fromCacheTtl(),
-    truncateFrontToSize?: number
+    truncateFrontToSize?: number,
+    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheListPushBack.Response> {
     try {
       validateCacheName(cacheName);
@@ -790,7 +790,7 @@ export class CacheClient {
     this.logger.trace(
       `Issuing 'listPushBack' request; listName: ${listName}, value length: ${
         value.length
-      }, ${ttl.toString()}, truncateFrontToSize: ${
+      }, ${collectionTtl.toString()}, truncateFrontToSize: ${
         truncateFrontToSize?.toString() ?? 'null'
       }`
     );
@@ -799,8 +799,8 @@ export class CacheClient {
       cacheName,
       this.convert(listName),
       this.convert(value),
-      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      ttl.refreshTtl(),
+      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      collectionTtl.refreshTtl(),
       truncateFrontToSize
     );
     this.logger.trace(`'listPushBack' request result: ${result.toString()}`);
@@ -845,8 +845,8 @@ export class CacheClient {
     cacheName: string,
     listName: string,
     value: string | Uint8Array,
-    ttl: CollectionTtl = CollectionTtl.fromCacheTtl(),
-    truncateBackToSize?: number
+    truncateBackToSize?: number,
+    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheListPushFront.Response> {
     try {
       validateCacheName(cacheName);
@@ -858,7 +858,7 @@ export class CacheClient {
     this.logger.trace(
       `Issuing 'listPushFront' request; listName: ${listName}, value length: ${
         value.length
-      }, ${ttl.toString()}, truncateBackToSize: ${
+      }, ${collectionTtl.toString()}, truncateBackToSize: ${
         truncateBackToSize?.toString() ?? 'null'
       }`
     );
@@ -867,8 +867,8 @@ export class CacheClient {
       cacheName,
       this.convert(listName),
       this.convert(value),
-      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      ttl.refreshTtl(),
+      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      collectionTtl.refreshTtl(),
       truncateBackToSize
     );
     this.logger.trace(`'listPushFront' request result: ${result.toString()}`);
@@ -1089,7 +1089,7 @@ export class CacheClient {
     items:
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>,
-    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    collectionTtl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheDictionarySetFields.Response> {
     try {
       validateCacheName(cacheName);
@@ -1101,7 +1101,7 @@ export class CacheClient {
     }
     this.logger.trace(
       `Issuing 'dictionarySetFields' request; items: ${items.toString()}, ttl: ${
-        ttl.ttlSeconds.toString() ?? 'null'
+        collectionTtl.ttlSeconds.toString() ?? 'null'
       }`
     );
 
@@ -1111,8 +1111,8 @@ export class CacheClient {
       cacheName,
       this.convert(dictionaryName),
       dictionaryFieldValuePairs,
-      ttl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
-      ttl.refreshTtl()
+      collectionTtl.ttlMilliseconds() || this.defaultTtlSeconds * 1000,
+      collectionTtl.refreshTtl()
     );
     this.logger.trace(
       `'dictionarySetFields' request result: ${result.toString()}`

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -40,8 +40,20 @@ import {
   BackTruncatableCallOptions,
   CollectionCallOptions,
   FrontTruncatableCallOptions,
-  SingleCallOptions,
+  ScalarCallOptions,
 } from './utils/cache-call-options';
+
+// Type aliases to differentiate the different methods' optional arguments.
+type SetOptions = ScalarCallOptions;
+type ListConcatenateBackOptions = FrontTruncatableCallOptions;
+type ListConcatenateFrontOptions = BackTruncatableCallOptions;
+type ListPushBackOptions = FrontTruncatableCallOptions;
+type ListPushFrontOptions = BackTruncatableCallOptions;
+type SetAddElementOptions = CollectionCallOptions;
+type SetAddElementsOptions = CollectionCallOptions;
+type DictionarySetFieldOptions = CollectionCallOptions;
+type DictionarySetFieldsOptions = CollectionCallOptions;
+type DictionaryIncrementOptions = CollectionCallOptions;
 
 /**
  * Momento Simple Cache Client.
@@ -111,7 +123,7 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the item in.
    * @param {(string | Uint8Array)} key - The key to set.
    * @param {(string | Uint8Array)} value - The value to be stored.
-   * @param {SingleCallOptions} [options]
+   * @param {SetOptions} [options]
    * @param {number} [options.ttl] - Time to live (TTL) for the item in Cache.
    * This TTL takes precedence over the TTL used when initializing a cache client.
    * @returns {Promise<CacheSet.Response>} - Result of the set operation.
@@ -121,7 +133,7 @@ export class SimpleCacheClient {
     cacheName: string,
     key: string | Uint8Array,
     value: string | Uint8Array,
-    options?: SingleCallOptions
+    options?: SetOptions
   ): Promise<CacheSet.Response> {
     const client = this.getNextDataClient();
     return await client.set(cacheName, key, value, options?.ttl);
@@ -150,7 +162,7 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the list in.
    * @param {string} listName - The list to add to.
    * @param {string[] | Uint8Array[]} values - The values to add to the list.
-   * @param {FrontTruncatableCallOptions} [options]
+   * @param {ListConcatenateBackOptions} [options]
    * @param {number} [options.truncateFrontToSize] - If the list exceeds this
    * length, remove excess from the start of the list. Must be positive.
    * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
@@ -161,7 +173,7 @@ export class SimpleCacheClient {
     cacheName: string,
     listName: string,
     values: string[] | Uint8Array[],
-    options?: FrontTruncatableCallOptions
+    options?: ListConcatenateBackOptions
   ): Promise<CacheListConcatenateBack.Response> {
     const client = this.getNextDataClient();
     return await client.listConcatenateBack(
@@ -180,7 +192,7 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the list in.
    * @param {string} listName - The list to add to.
    * @param {string[] | Uint8Array[]} values - The values to add to the list.
-   * @param {BackTruncatableCallOptions} [options]
+   * @param {ListConcatenateFrontOptions} [options]
    * @param {number} [options.truncateBackToSize] - If the list exceeds this
    * length, remove excess from the end of the list. Must be positive.
    * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
@@ -191,7 +203,7 @@ export class SimpleCacheClient {
     cacheName: string,
     listName: string,
     values: string[] | Uint8Array[],
-    options?: BackTruncatableCallOptions
+    options?: ListConcatenateFrontOptions
   ): Promise<CacheListConcatenateFront.Response> {
     const client = this.getNextDataClient();
     return await client.listConcatenateFront(
@@ -263,7 +275,7 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache with the list.
    * @param {string} listName - The list to push to.
    * @param {string | Uint8Array} value - The value to push.
-   * @param {FrontTruncatableCallOptions} [options]
+   * @param {ListPushBackOptions} [options]
    * @param {number} [options.truncateFrontToSize] - If the list exceeds this
    * length, remove excess from the start of the list. Must be positive.
    * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
@@ -274,7 +286,7 @@ export class SimpleCacheClient {
     cacheName: string,
     listName: string,
     value: string | Uint8Array,
-    options?: FrontTruncatableCallOptions
+    options?: ListPushBackOptions
   ): Promise<CacheListPushBack.Response> {
     const client = this.getNextDataClient();
     return await client.listPushBack(
@@ -291,7 +303,7 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache with the list.
    * @param {string} listName - The list to push to.
    * @param {string | Uint8Array} value - The value to push.
-   * @param {BackTruncatableCallOptions} [options]
+   * @param {ListPushFrontOptions} [options]
    * @param {number} [options.truncateBackToSize] - If the list exceeds this
    * length, remove excess from the end of the list. Must be positive.
    * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
@@ -302,7 +314,7 @@ export class SimpleCacheClient {
     cacheName: string,
     listName: string,
     value: string | Uint8Array,
-    options?: BackTruncatableCallOptions
+    options?: ListPushFrontOptions
   ): Promise<CacheListPushFront.Response> {
     const client = this.getNextDataClient();
     return await client.listPushFront(
@@ -353,15 +365,15 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the set in.
    * @param {string} setName - The set to add elements to.
    * @param {(string | Uint8Array)} element - The data to add to the set.
-   * @param {CollectionCallOptions} options
-   * @param {number} [options.ttl] - TTL for the set in cache. This TTL takes
+   * @param {SetAddElementOptions} options
+   * @param {CollectionTtl} [options.ttl] - TTL for the set in cache. This TTL takes
    * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    */
   public async setAddElement(
     cacheName: string,
     setName: string,
     element: string | Uint8Array,
-    options?: CollectionCallOptions
+    options?: SetAddElementOptions
   ): Promise<CacheSetAddElement.Response> {
     return (
       await this.setAddElements(
@@ -381,15 +393,15 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the set in.
    * @param {string} setName - The set to add elements to.
    * @param {(string[] | Uint8Array[])} elements - The data to add to the set.
-   * @param {CollectionCallOptions} options
-   * @param {number} [options.ttl] - TTL for the set in cache. This TTL takes
+   * @param {SetAddElementsOptions} options
+   * @param {CollectionTtl} [options.ttl] - TTL for the set in cache. This TTL takes
    * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    */
   public async setAddElements(
     cacheName: string,
     setName: string,
     elements: string[] | Uint8Array[],
-    options?: CollectionCallOptions
+    options?: SetAddElementsOptions
   ): Promise<CacheSetAddElements.Response> {
     const client = this.getNextDataClient();
     return await client.setAddElements(
@@ -492,8 +504,8 @@ export class SimpleCacheClient {
    * @param {string} dictionaryName - The dictionary to set.
    * @param {string | Uint8Array} field - The field in the dictionary to set.
    * @param {string | Uint8Array} value - The value to be stored.
-   * @param {CollectionCallOptions} options
-   * @param {number} [options.ttl] - TTL for the dictionary in cache. This TTL takes
+   * @param {DictionarySetFieldOptions} options
+   * @param {CollectionTtl} [options.ttl] - TTL for the dictionary in cache. This TTL takes
    * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    * @returns {Promise<CacheDictionarySetField.Response>}- Promise containing the result of the cache operation.
    * @memberof SimpleCacheClient
@@ -503,7 +515,7 @@ export class SimpleCacheClient {
     dictionaryName: string,
     field: string | Uint8Array,
     value: string | Uint8Array,
-    options?: CollectionCallOptions
+    options?: DictionarySetFieldOptions
   ): Promise<CacheDictionarySetField.Response> {
     const client = this.getNextDataClient();
     return await client.dictionarySendField(
@@ -520,8 +532,8 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the dictionary in.
    * @param {string} dictionaryName - The dictionary to set.
    * @param {Map<string | Uint8Array, string | Uint8Array>} items - The field-value pairs in the dictionary to set.
-   * @param {CollectionCallOptions} options
-   * @param {number} [options.ttl] - TTL for the dictionary in cache. This TTL takes
+   * @param {DictionarySetFieldsOptions} options
+   * @param {CollectionTtl} [options.ttl] - TTL for the dictionary in cache. This TTL takes
    * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    * @returns {Promise<CacheDictionarySetFields.Response>}- Promise containing the result of the cache operation.
    * @memberof SimpleCacheClient
@@ -532,7 +544,7 @@ export class SimpleCacheClient {
     items:
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>,
-    options?: CollectionCallOptions
+    options?: DictionarySetFieldsOptions
   ): Promise<CacheDictionarySetFields.Response> {
     const client = this.getNextDataClient();
     return await client.dictionarySendFields(
@@ -622,8 +634,8 @@ export class SimpleCacheClient {
    * @param {string} dictionaryName - The dictionary to set.
    * @param {string | Uint8Array} field - Name of the field to increment from the dictionary.
    * @param {number} amount - The quantity to add to the value. May be positive, negative, or zero. Defaults to 1.
-   * @param {CollectionCallOptions} options
-   * @param {number} [options.ttl] - TTL for the dictionary in cache. This TTL takes
+   * @param {DictionaryIncrementOptions} options
+   * @param {CollectionTtl} [options.ttl] - TTL for the dictionary in cache. This TTL takes
    * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    * @returns {Promise<CacheDictionaryIncrement>}- Promise containing the result of the cache operation.
    */
@@ -632,7 +644,7 @@ export class SimpleCacheClient {
     dictionaryName: string,
     field: string | Uint8Array,
     amount = 1,
-    options?: CollectionCallOptions
+    options?: DictionaryIncrementOptions
   ): Promise<CacheDictionaryIncrement.Response> {
     const client = this.getNextDataClient();
     return await client.dictionaryIncrement(

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -144,24 +144,24 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the list in.
    * @param {string} listName - The list to add to.
    * @param {string[] | Uint8Array[]} values - The values to add to the list.
-   * @param {CollectionTtl} [ttl] - How the ttl should be managed. Defaults to the client's TTL.
    * @param {number} [truncateFrontToSize] - If the list exceeds this length, remove excess from the start of the list. Must be positive.
+   * @param {CollectionTtl} [collectionTtl] - How the ttl should be managed. Defaults to the client's TTL.
    * @returns {Promise<CacheListConcatenateBack.Response>}
    */
   public async listConcatenateBack(
     cacheName: string,
     listName: string,
     values: string[] | Uint8Array[],
-    ttl?: CollectionTtl,
-    truncateFrontToSize?: number
+    truncateFrontToSize?: number,
+    collectionTtl?: CollectionTtl
   ): Promise<CacheListConcatenateBack.Response> {
     const client = this.getNextDataClient();
     return await client.listConcatenateBack(
       cacheName,
       listName,
       values,
-      ttl,
-      truncateFrontToSize
+      truncateFrontToSize,
+      collectionTtl
     );
   }
 
@@ -172,24 +172,24 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the list in.
    * @param {string} listName - The list to add to.
    * @param {string[] | Uint8Array[]} values - The values to add to the list.
-   * @param {CollectionTtl} [ttl] - How the ttl should be managed. Defaults to the client's TTL.
    * @param {number} [truncateBackToSize] - If the list exceeds this length, remove excess from the end of the list. Must be positive.
+   * @param {CollectionTtl} [collectionTtl] - How the ttl should be managed. Defaults to the client's TTL.
    * @returns {Promise<CacheListConcatenateFront.Response>}
    */
   public async listConcatenateFront(
     cacheName: string,
     listName: string,
     values: string[] | Uint8Array[],
-    ttl?: CollectionTtl,
-    truncateBackToSize?: number
+    truncateBackToSize?: number,
+    collectionTtl?: CollectionTtl
   ): Promise<CacheListConcatenateFront.Response> {
     const client = this.getNextDataClient();
     return await client.listConcatenateFront(
       cacheName,
       listName,
       values,
-      ttl,
-      truncateBackToSize
+      truncateBackToSize,
+      collectionTtl
     );
   }
 
@@ -252,25 +252,25 @@ export class SimpleCacheClient {
    * Add a value to the beginning of a list.
    * @param {string} cacheName - Name of the cache with the list.
    * @param {string} listName - The list to push to.
-   * @param {string | Uint8Array} - The value to push.
-   * @param {CollectionTtl} [ttl] - How the ttl should be managed. Defaults to the client's TTL.
+   * @param {string | Uint8Array} value - The value to push.
    * @param {number} [truncateFrontToSize] - If the list exceeds this length, remove excess from the start of the list. Must be positive.
+   * @param {CollectionTtl} [collectionTtl] - How the ttl should be managed. Defaults to the client's TTL.
    * @return {Promise<CacheListPushBack.Response>}
    */
   public async listPushBack(
     cacheName: string,
     listName: string,
     value: string | Uint8Array,
-    ttl?: CollectionTtl,
-    truncateFrontToSize?: number
+    truncateFrontToSize?: number,
+    collectionTtl?: CollectionTtl
   ): Promise<CacheListPushBack.Response> {
     const client = this.getNextDataClient();
     return await client.listPushBack(
       cacheName,
       listName,
       value,
-      ttl,
-      truncateFrontToSize
+      truncateFrontToSize,
+      collectionTtl
     );
   }
 
@@ -278,25 +278,25 @@ export class SimpleCacheClient {
    * Add a value to the end of a list.
    * @param {string} cacheName - Name of the cache with the list.
    * @param {string} listName - The list to push to.
-   * @param {string | Uint8Array} - The value to push.
-   * @param {CollectionTtl} [ttl] - How the ttl should be managed. Defaults to the client's TTL.
+   * @param {string | Uint8Array} value - The value to push.
    * @param {number} [truncateBackToSize] - If the list exceeds this length, remove excess from the end of the list. Must be positive.
+   * @param {CollectionTtl} [collectionTtl] - How the ttl should be managed. Defaults to the client's TTL.
    * @return {Promise<CacheListPushFront.Response>}
    */
   public async listPushFront(
     cacheName: string,
     listName: string,
     value: string | Uint8Array,
-    ttl?: CollectionTtl,
-    truncateBackToSize?: number
+    truncateBackToSize?: number,
+    collectionTtl?: CollectionTtl
   ): Promise<CacheListPushFront.Response> {
     const client = this.getNextDataClient();
     return await client.listPushFront(
       cacheName,
       listName,
       value,
-      ttl,
-      truncateBackToSize
+      truncateBackToSize,
+      collectionTtl
     );
   }
 
@@ -339,20 +339,20 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the set in.
    * @param {string} setName - The set to add elements to.
    * @param {(string | Uint8Array)} element - The data to add to the set.
-   * @param {CollectionTtl} [ttl] - TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+   * @param {CollectionTtl} [collectionTtl] - TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    */
   public async setAddElement(
     cacheName: string,
     setName: string,
     element: string | Uint8Array,
-    ttl?: CollectionTtl
+    collectionTtl?: CollectionTtl
   ): Promise<CacheSetAddElement.Response> {
     return (
       await this.setAddElements(
         cacheName,
         setName,
         [element] as string[] | Uint8Array[],
-        ttl
+        collectionTtl
       )
     ).toSingularResponse();
   }
@@ -365,16 +365,21 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the set in.
    * @param {string} setName - The set to add elements to.
    * @param {(string[] | Uint8Array[])} elements - The data to add to the set.
-   * @param {CollectionTtl} [ttl] - TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+   * @param {CollectionTtl} [collectionTtl] - TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    */
   public async setAddElements(
     cacheName: string,
     setName: string,
     elements: string[] | Uint8Array[],
-    ttl?: CollectionTtl
+    collectionTtl?: CollectionTtl
   ): Promise<CacheSetAddElements.Response> {
     const client = this.getNextDataClient();
-    return await client.setAddElements(cacheName, setName, elements, ttl);
+    return await client.setAddElements(
+      cacheName,
+      setName,
+      elements,
+      collectionTtl
+    );
   }
 
   /**
@@ -495,7 +500,7 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the dictionary in.
    * @param {string} dictionaryName - The dictionary to set.
    * @param {Map<string | Uint8Array, string | Uint8Array>} items - The field-value pairs in the dictionary to set.
-   * @param {CollectionTtl} ttl -  TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+   * @param {CollectionTtl} collectionTtl -  TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    * @returns {Promise<CacheDictionarySetFields.Response>}- Promise containing the result of the cache operation.
    * @memberof SimpleCacheClient
    */
@@ -505,14 +510,14 @@ export class SimpleCacheClient {
     items:
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>,
-    ttl?: CollectionTtl
+    collectionTtl?: CollectionTtl
   ): Promise<CacheDictionarySetFields.Response> {
     const client = this.getNextDataClient();
     return await client.dictionarySendFields(
       cacheName,
       dictionaryName,
       items,
-      ttl
+      collectionTtl
     );
   }
 
@@ -595,7 +600,7 @@ export class SimpleCacheClient {
    * @param {string} dictionaryName - The dictionary to set.
    * @param {string | Uint8Array} field - Name of the field to increment from the dictionary.
    * @param {number} amount - The quantity to add to the value. May be positive, negative, or zero. Defaults to 1.
-   * @param {CollectionTtl} ttl - TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+   * @param {CollectionTtl} collectionTtl - TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    * @returns {Promise<CacheDictionaryIncrement>}- Promise containing the result of the cache operation.
    */
   public async dictionaryIncrement(
@@ -603,7 +608,7 @@ export class SimpleCacheClient {
     dictionaryName: string,
     field: string | Uint8Array,
     amount = 1,
-    ttl?: CollectionTtl
+    collectionTtl?: CollectionTtl
   ): Promise<CacheDictionaryIncrement.Response> {
     const client = this.getNextDataClient();
     return await client.dictionaryIncrement(
@@ -611,7 +616,7 @@ export class SimpleCacheClient {
       dictionaryName,
       field,
       amount,
-      ttl
+      collectionTtl
     );
   }
 

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -1,7 +1,6 @@
 import {ControlClient} from './internal/control-client';
 import {CacheClient} from './internal/cache-client';
 import {
-  CollectionTtl,
   Configuration,
   CredentialProvider,
   CreateCache,
@@ -37,6 +36,12 @@ import {
 } from '.';
 import {range} from './internal/utils/collections';
 import {SimpleCacheClientProps} from './simple-cache-client-props';
+import {
+  BackTruncatableCallOptions,
+  CollectionCallOptions,
+  FrontTruncatableCallOptions,
+  SingleCallOptions,
+} from './utils/cache-call-options';
 
 /**
  * Momento Simple Cache Client.
@@ -106,7 +111,8 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the item in.
    * @param {(string | Uint8Array)} key - The key to set.
    * @param {(string | Uint8Array)} value - The value to be stored.
-   * @param {number} [ttl] - Time to live (TTL) for the item in Cache.
+   * @param {SingleCallOptions} [options]
+   * @param {number} [options.ttl] - Time to live (TTL) for the item in Cache.
    * This TTL takes precedence over the TTL used when initializing a cache client.
    * @returns {Promise<CacheSet.Response>} - Result of the set operation.
    * @memberof SimpleCacheClient
@@ -115,10 +121,10 @@ export class SimpleCacheClient {
     cacheName: string,
     key: string | Uint8Array,
     value: string | Uint8Array,
-    ttl?: number
+    options?: SingleCallOptions
   ): Promise<CacheSet.Response> {
     const client = this.getNextDataClient();
-    return await client.set(cacheName, key, value, ttl);
+    return await client.set(cacheName, key, value, options?.ttl);
   }
 
   /**
@@ -144,24 +150,26 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the list in.
    * @param {string} listName - The list to add to.
    * @param {string[] | Uint8Array[]} values - The values to add to the list.
-   * @param {number} [truncateFrontToSize] - If the list exceeds this length, remove excess from the start of the list. Must be positive.
-   * @param {CollectionTtl} [collectionTtl] - How the ttl should be managed. Defaults to the client's TTL.
+   * @param {FrontTruncatableCallOptions} [options]
+   * @param {number} [options.truncateFrontToSize] - If the list exceeds this
+   * length, remove excess from the start of the list. Must be positive.
+   * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
+   * Defaults to the client's TTL.
    * @returns {Promise<CacheListConcatenateBack.Response>}
    */
   public async listConcatenateBack(
     cacheName: string,
     listName: string,
     values: string[] | Uint8Array[],
-    truncateFrontToSize?: number,
-    collectionTtl?: CollectionTtl
+    options?: FrontTruncatableCallOptions
   ): Promise<CacheListConcatenateBack.Response> {
     const client = this.getNextDataClient();
     return await client.listConcatenateBack(
       cacheName,
       listName,
       values,
-      truncateFrontToSize,
-      collectionTtl
+      options?.truncateFrontToSize,
+      options?.ttl
     );
   }
 
@@ -172,24 +180,26 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the list in.
    * @param {string} listName - The list to add to.
    * @param {string[] | Uint8Array[]} values - The values to add to the list.
-   * @param {number} [truncateBackToSize] - If the list exceeds this length, remove excess from the end of the list. Must be positive.
-   * @param {CollectionTtl} [collectionTtl] - How the ttl should be managed. Defaults to the client's TTL.
+   * @param {BackTruncatableCallOptions} [options]
+   * @param {number} [options.truncateBackToSize] - If the list exceeds this
+   * length, remove excess from the end of the list. Must be positive.
+   * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
+   * Defaults to the client's TTL.
    * @returns {Promise<CacheListConcatenateFront.Response>}
    */
   public async listConcatenateFront(
     cacheName: string,
     listName: string,
     values: string[] | Uint8Array[],
-    truncateBackToSize?: number,
-    collectionTtl?: CollectionTtl
+    options?: BackTruncatableCallOptions
   ): Promise<CacheListConcatenateFront.Response> {
     const client = this.getNextDataClient();
     return await client.listConcatenateFront(
       cacheName,
       listName,
       values,
-      truncateBackToSize,
-      collectionTtl
+      options?.truncateBackToSize,
+      options?.ttl
     );
   }
 
@@ -253,24 +263,26 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache with the list.
    * @param {string} listName - The list to push to.
    * @param {string | Uint8Array} value - The value to push.
-   * @param {number} [truncateFrontToSize] - If the list exceeds this length, remove excess from the start of the list. Must be positive.
-   * @param {CollectionTtl} [collectionTtl] - How the ttl should be managed. Defaults to the client's TTL.
+   * @param {FrontTruncatableCallOptions} [options]
+   * @param {number} [options.truncateFrontToSize] - If the list exceeds this
+   * length, remove excess from the start of the list. Must be positive.
+   * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
+   * Defaults to the client's TTL.
    * @return {Promise<CacheListPushBack.Response>}
    */
   public async listPushBack(
     cacheName: string,
     listName: string,
     value: string | Uint8Array,
-    truncateFrontToSize?: number,
-    collectionTtl?: CollectionTtl
+    options?: FrontTruncatableCallOptions
   ): Promise<CacheListPushBack.Response> {
     const client = this.getNextDataClient();
     return await client.listPushBack(
       cacheName,
       listName,
       value,
-      truncateFrontToSize,
-      collectionTtl
+      options?.truncateFrontToSize,
+      options?.ttl
     );
   }
 
@@ -279,24 +291,26 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache with the list.
    * @param {string} listName - The list to push to.
    * @param {string | Uint8Array} value - The value to push.
-   * @param {number} [truncateBackToSize] - If the list exceeds this length, remove excess from the end of the list. Must be positive.
-   * @param {CollectionTtl} [collectionTtl] - How the ttl should be managed. Defaults to the client's TTL.
+   * @param {BackTruncatableCallOptions} [options]
+   * @param {number} [options.truncateBackToSize] - If the list exceeds this
+   * length, remove excess from the end of the list. Must be positive.
+   * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
+   * Defaults to the client's TTL.
    * @return {Promise<CacheListPushFront.Response>}
    */
   public async listPushFront(
     cacheName: string,
     listName: string,
     value: string | Uint8Array,
-    truncateBackToSize?: number,
-    collectionTtl?: CollectionTtl
+    options?: BackTruncatableCallOptions
   ): Promise<CacheListPushFront.Response> {
     const client = this.getNextDataClient();
     return await client.listPushFront(
       cacheName,
       listName,
       value,
-      truncateBackToSize,
-      collectionTtl
+      options?.truncateBackToSize,
+      options?.ttl
     );
   }
 
@@ -339,20 +353,22 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the set in.
    * @param {string} setName - The set to add elements to.
    * @param {(string | Uint8Array)} element - The data to add to the set.
-   * @param {CollectionTtl} [collectionTtl] - TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+   * @param {CollectionCallOptions} options
+   * @param {number} [options.ttl] - TTL for the set in cache. This TTL takes
+   * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    */
   public async setAddElement(
     cacheName: string,
     setName: string,
     element: string | Uint8Array,
-    collectionTtl?: CollectionTtl
+    options?: CollectionCallOptions
   ): Promise<CacheSetAddElement.Response> {
     return (
       await this.setAddElements(
         cacheName,
         setName,
         [element] as string[] | Uint8Array[],
-        collectionTtl
+        options
       )
     ).toSingularResponse();
   }
@@ -365,20 +381,22 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the set in.
    * @param {string} setName - The set to add elements to.
    * @param {(string[] | Uint8Array[])} elements - The data to add to the set.
-   * @param {CollectionTtl} [collectionTtl] - TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+   * @param {CollectionCallOptions} options
+   * @param {number} [options.ttl] - TTL for the set in cache. This TTL takes
+   * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    */
   public async setAddElements(
     cacheName: string,
     setName: string,
     elements: string[] | Uint8Array[],
-    collectionTtl?: CollectionTtl
+    options?: CollectionCallOptions
   ): Promise<CacheSetAddElements.Response> {
     const client = this.getNextDataClient();
     return await client.setAddElements(
       cacheName,
       setName,
       elements,
-      collectionTtl
+      options?.ttl
     );
   }
 
@@ -472,9 +490,11 @@ export class SimpleCacheClient {
    * After this operation, the set will contain the union of the element passed in and the elements of the set.
    * @param {string} cacheName - Name of the cache to store the dictionary in.
    * @param {string} dictionaryName - The dictionary to set.
-   * @param {string | Uint8Array} items - The field in the dictionary to set.
+   * @param {string | Uint8Array} field - The field in the dictionary to set.
    * @param {string | Uint8Array} value - The value to be stored.
-   * @param {CollectionTtl} ttl -  TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+   * @param {CollectionCallOptions} options
+   * @param {number} [options.ttl] - TTL for the dictionary in cache. This TTL takes
+   * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    * @returns {Promise<CacheDictionarySetField.Response>}- Promise containing the result of the cache operation.
    * @memberof SimpleCacheClient
    */
@@ -483,7 +503,7 @@ export class SimpleCacheClient {
     dictionaryName: string,
     field: string | Uint8Array,
     value: string | Uint8Array,
-    ttl?: CollectionTtl
+    options?: CollectionCallOptions
   ): Promise<CacheDictionarySetField.Response> {
     const client = this.getNextDataClient();
     return await client.dictionarySendField(
@@ -491,7 +511,7 @@ export class SimpleCacheClient {
       dictionaryName,
       field,
       value,
-      ttl
+      options?.ttl
     );
   }
 
@@ -500,7 +520,9 @@ export class SimpleCacheClient {
    * @param {string} cacheName - Name of the cache to store the dictionary in.
    * @param {string} dictionaryName - The dictionary to set.
    * @param {Map<string | Uint8Array, string | Uint8Array>} items - The field-value pairs in the dictionary to set.
-   * @param {CollectionTtl} collectionTtl -  TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+   * @param {CollectionCallOptions} options
+   * @param {number} [options.ttl] - TTL for the dictionary in cache. This TTL takes
+   * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    * @returns {Promise<CacheDictionarySetFields.Response>}- Promise containing the result of the cache operation.
    * @memberof SimpleCacheClient
    */
@@ -510,14 +532,14 @@ export class SimpleCacheClient {
     items:
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>,
-    collectionTtl?: CollectionTtl
+    options?: CollectionCallOptions
   ): Promise<CacheDictionarySetFields.Response> {
     const client = this.getNextDataClient();
     return await client.dictionarySendFields(
       cacheName,
       dictionaryName,
       items,
-      collectionTtl
+      options?.ttl
     );
   }
 
@@ -600,7 +622,9 @@ export class SimpleCacheClient {
    * @param {string} dictionaryName - The dictionary to set.
    * @param {string | Uint8Array} field - Name of the field to increment from the dictionary.
    * @param {number} amount - The quantity to add to the value. May be positive, negative, or zero. Defaults to 1.
-   * @param {CollectionTtl} collectionTtl - TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+   * @param {CollectionCallOptions} options
+   * @param {number} [options.ttl] - TTL for the dictionary in cache. This TTL takes
+   * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
    * @returns {Promise<CacheDictionaryIncrement>}- Promise containing the result of the cache operation.
    */
   public async dictionaryIncrement(
@@ -608,7 +632,7 @@ export class SimpleCacheClient {
     dictionaryName: string,
     field: string | Uint8Array,
     amount = 1,
-    collectionTtl?: CollectionTtl
+    options?: CollectionCallOptions
   ): Promise<CacheDictionaryIncrement.Response> {
     const client = this.getNextDataClient();
     return await client.dictionaryIncrement(
@@ -616,7 +640,7 @@ export class SimpleCacheClient {
       dictionaryName,
       field,
       amount,
-      collectionTtl
+      options?.ttl
     );
   }
 

--- a/src/utils/cache-call-options.ts
+++ b/src/utils/cache-call-options.ts
@@ -1,6 +1,6 @@
 import {CollectionTtl} from './collection-ttl';
 
-export interface SingleCallOptions {
+export interface ScalarCallOptions {
   /**
    * The time to live in seconds of the object being modified.
    */
@@ -18,12 +18,12 @@ export interface FrontTruncatableCallOptions extends CollectionCallOptions {
   /**
    * If the collection exceeds this length, remove excess from the start of the list. Must be positive.
    */
-  truncateFrontToSize?: number; //separate front and back
+  truncateFrontToSize?: number;
 }
 
 export interface BackTruncatableCallOptions extends CollectionCallOptions {
   /**
    * If the collection exceeds this length, remove excess from the end of the list. Must be positive.
    */
-  truncateBackToSize?: number; //separate front and back
+  truncateBackToSize?: number;
 }

--- a/src/utils/cache-call-options.ts
+++ b/src/utils/cache-call-options.ts
@@ -1,0 +1,29 @@
+import {CollectionTtl} from './collection-ttl';
+
+export interface SingleCallOptions {
+  /**
+   * The time to live in seconds of the object being modified.
+   */
+  ttl?: number;
+}
+
+export interface CollectionCallOptions {
+  /**
+   * The length of the TTL and whether it should be refreshed when the collection is modified.
+   */
+  ttl?: CollectionTtl;
+}
+
+export interface FrontTruncatableCallOptions extends CollectionCallOptions {
+  /**
+   * If the collection exceeds this length, remove excess from the start of the list. Must be positive.
+   */
+  truncateFrontToSize?: number; //separate front and back
+}
+
+export interface BackTruncatableCallOptions extends CollectionCallOptions {
+  /**
+   * If the collection exceeds this length, remove excess from the end of the list. Must be positive.
+   */
+  truncateBackToSize?: number; //separate front and back
+}


### PR DESCRIPTION
Create interfaces for the optional api arguments. This forces them to be
named and lets them be supplied in any order. Methods with only one
optional argument still get an interface for consistency.