### PR TITLE
fix: change dictionary argument names from items to elements

### DIFF
--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -1083,10 +1083,10 @@ export class CacheClient {
     });
   }
 
-  public async dictionarySendFields(
+  public async dictionarySetFields(
     cacheName: string,
     dictionaryName: string,
-    items:
+    elements:
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>,
     ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
@@ -1100,12 +1100,12 @@ export class CacheClient {
       );
     }
     this.logger.trace(
-      `Issuing 'dictionarySetFields' request; items: ${items.toString()}, ttl: ${
+      `Issuing 'dictionarySetFields' request; elements: ${elements.toString()}, ttl: ${
         ttl.ttlSeconds.toString() ?? 'null'
       }`
     );
 
-    const dictionaryFieldValuePairs = this.convertMapOrRecord(items);
+    const dictionaryFieldValuePairs = this.convertMapOrRecord(elements);
 
     const result = await this.sendDictionarySetFields(
       cacheName,
@@ -1123,13 +1123,13 @@ export class CacheClient {
   private async sendDictionarySetFields(
     cacheName: string,
     dictionaryName: Uint8Array,
-    items: grpcCache._DictionaryFieldValuePair[],
+    elements: grpcCache._DictionaryFieldValuePair[],
     ttlMilliseconds: number,
     refreshTtl: boolean
   ): Promise<CacheDictionarySetFields.Response> {
     const request = new grpcCache._DictionarySetRequest({
       dictionary_name: dictionaryName,
-      items: items,
+      items: elements,
       ttl_milliseconds: ttlMilliseconds,
       refresh_ttl: refreshTtl,
     });
@@ -1520,24 +1520,24 @@ export class CacheClient {
   }
 
   private convertMapOrRecord(
-    items:
+    elements:
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>
   ): grpcCache._DictionaryFieldValuePair[] {
-    if (items instanceof Map) {
-      return [...items.entries()].map(
-        item =>
+    if (elements instanceof Map) {
+      return [...elements.entries()].map(
+        element =>
           new grpcCache._DictionaryFieldValuePair({
-            field: this.convert(item[0]),
-            value: this.convert(item[1]),
+            field: this.convert(element[0]),
+            value: this.convert(element[1]),
           })
       );
     } else {
-      return Object.entries(items).map(
-        item =>
+      return Object.entries(elements).map(
+        element =>
           new grpcCache._DictionaryFieldValuePair({
-            field: this.convert(item[0]),
-            value: this.convert(item[1]),
+            field: this.convert(element[0]),
+            value: this.convert(element[1]),
           })
       );
     }

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -531,7 +531,7 @@ export class SimpleCacheClient {
    * Set several dictionary field-value pairs in the cache.
    * @param {string} cacheName - Name of the cache to store the dictionary in.
    * @param {string} dictionaryName - The dictionary to set.
-   * @param {Map<string | Uint8Array, string | Uint8Array>} items - The field-value pairs in the dictionary to set.
+   * @param {Map<string | Uint8Array, string | Uint8Array>} elements - The field-value pairs in the dictionary to set.
    * @param {DictionarySetFieldsOptions} options
    * @param {CollectionTtl} [options.ttl] - TTL for the dictionary in cache. This TTL takes
    * precedence over the TTL used when initializing a cache client. Defaults to client TTL.
@@ -541,16 +541,16 @@ export class SimpleCacheClient {
   public async dictionarySetFields(
     cacheName: string,
     dictionaryName: string,
-    items:
+    elements:
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>,
     options?: DictionarySetFieldsOptions
   ): Promise<CacheDictionarySetFields.Response> {
     const client = this.getNextDataClient();
-    return await client.dictionarySendFields(
+    return await client.dictionarySetFields(
       cacheName,
       dictionaryName,
-      items,
+      elements,
       options?.ttl
     );
   }


### PR DESCRIPTION
As per our naming conversation today we want to standardize on the term 'elements' as a common vocabulary word for the contents of collections.  This commit changes the places in the dictionary API where we were referring to 'items' and replaces it with 'elements'.