### PR TITLE
feat: add some niceties for working with ListFetch/SetFetch response

### DIFF
--- a/integration/list.test.ts
+++ b/integration/list.test.ts
@@ -255,6 +255,7 @@ describe('lists', () => {
         await Momento.listFetch(IntegrationTestCacheName, listName)
       );
       expect(respFetch.valueListString()).toEqual([valueString]);
+      expect(respFetch.valueList()).toEqual([valueString]);
       expect(respFetch.valueListUint8Array()).toEqual([valueBytes]);
     });
   });

--- a/integration/set.test.ts
+++ b/integration/set.test.ts
@@ -218,9 +218,14 @@ describe('Integration Tests for operations on sets datastructure', () => {
       setName
     );
     expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
-    expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
+    const hit = fetchResponse as CacheSetFetch.Hit;
+    expect(hit.valueSetUint8Array()).toEqual(
       new Set([LOL_BYTE_ARRAY, FOO_BYTE_ARRAY])
     );
+    expect(hit.valueArrayUint8Array()).toEqual([
+      LOL_BYTE_ARRAY,
+      FOO_BYTE_ARRAY,
+    ]);
   });
   it('should succeed for addElements for string arrays happy path', async () => {
     const setName = v4();
@@ -236,9 +241,11 @@ describe('Integration Tests for operations on sets datastructure', () => {
       setName
     );
     expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
-    expect((fetchResponse as CacheSetFetch.Hit).valueSetString()).toEqual(
-      new Set(['lol', 'foo'])
-    );
+    const hit = fetchResponse as CacheSetFetch.Hit;
+    expect(hit.valueSet()).toEqual(new Set(['lol', 'foo']));
+    expect(hit.valueSetString()).toEqual(new Set(['lol', 'foo']));
+    expect(hit.valueArray()).toEqual(['lol', 'foo']);
+    expect(hit.valueArrayString()).toEqual(['lol', 'foo']);
   });
   it('should succeed for addElements with duplicate elements', async () => {
     const setName = v4();

--- a/src/messages/responses/cache-list-fetch.ts
+++ b/src/messages/responses/cache-list-fetch.ts
@@ -27,6 +27,10 @@ class _Hit extends Response {
     return this._values.map(v => TEXT_DECODER.decode(v));
   }
 
+  public valueList(): string[] {
+    return this.valueListString();
+  }
+
   public override toString(): string {
     const truncatedStringArray = truncateStringArray(this.valueListString());
     return `${super.toString()}: [${truncatedStringArray.toString()}]`;

--- a/src/messages/responses/cache-set-fetch.ts
+++ b/src/messages/responses/cache-set-fetch.ts
@@ -20,12 +20,55 @@ class _Hit extends Response {
     this.elements = elements;
   }
 
+  /**
+   * Convenience alias for {valueSetString}; call this if you want to get the elements back as a Set of strings
+   * @returns {Set<string>}
+   */
+  public valueSet(): Set<string> {
+    return this.valueSetString();
+  }
+
+  /**
+   * Call this if you want to get the elements back as a Set of strings
+   * @returns {Set<string>}
+   */
   public valueSetString(): Set<string> {
     return new Set(this.elements.map(e => TEXT_DECODER.decode(e)));
   }
 
+  /**
+   * Call this if you want to get the elements back as a Set of byte arrays
+   * @returns {Set<Uint8Array>}
+   */
   public valueSetUint8Array(): Set<Uint8Array> {
     return new Set(this.elements);
+  }
+
+  /**
+   * Convenience alias for {valueArrayString}; call this if you want to get the elements back as an Array of strings, since
+   * sometimes Array objects are easier to work with than Sets
+   * @returns {string[]}
+   */
+  public valueArray(): string[] {
+    return this.valueArrayString();
+  }
+
+  /**
+   * Call this if you want to get the elements back as an Array of strings, since
+   * sometimes Array objects are easier to work with than Sets
+   * @returns {string[]}
+   */
+  public valueArrayString(): string[] {
+    return this.elements.map(e => TEXT_DECODER.decode(e));
+  }
+
+  /**
+   * Call this if you want to get the elements back as an Array of byte arrays, since
+   * sometimes Array objects are easier to work with than Sets
+   * @returns {Uint8Array[]}
+   */
+  public valueArrayUint8Array(): Uint8Array[] {
+    return this.elements;
   }
 
   public override toString(): string {


### PR DESCRIPTION
In some recent commits we added some niceties for working with Dictionary responses.  In particular we added shorthand-aliases for the `*String` accessors, and we added support for Record types because they are more idiomatic to work with in JS than Map types.

Similarly in this commit we:
* Add shorthand-aliases for the `*String` accessors for Lists
* Add shorthand-aliases for the `*String` accessors for Sets
* Add `valueArray*` accessors alongside the `valueSet*` accessors for Sets, because Arrays are easier to work with in JS and more idiomatic for some workflows.