### PR TITLE
fix: remove withLoggerFactory from Configurations

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -31,13 +31,6 @@ export interface Configuration {
   getLoggerFactory(): MomentoLoggerFactory;
 
   /**
-   * Copy constructor for overriding LoggerOptions
-   * @param {MomentoLoggerFactory} loggerFactory
-   * @returns {Configuration} a new Configuration object with the specified LoggerOptions
-   */
-  withLoggerFactory(loggerFactory: MomentoLoggerFactory): Configuration;
-
-  /**
    * @returns {RetryStrategy} the current configuration options for how and when failed requests will be retried
    */
   getRetryStrategy(): RetryStrategy;
@@ -82,14 +75,6 @@ export class SimpleCacheConfiguration implements Configuration {
 
   getLoggerFactory(): MomentoLoggerFactory {
     return this.loggerFactory;
-  }
-
-  withLoggerFactory(loggerFactory: MomentoLoggerFactory): Configuration {
-    return new SimpleCacheConfiguration({
-      loggerFactory: loggerFactory,
-      retryStrategy: this.retryStrategy,
-      transportStrategy: this.transportStrategy,
-    });
   }
 
   getRetryStrategy(): RetryStrategy {

--- a/test/config/configuration.test.ts
+++ b/test/config/configuration.test.ts
@@ -4,7 +4,6 @@ import {
   StaticTransportStrategy,
 } from '../../src/config/transport/transport-strategy';
 import {FixedCountRetryStrategy} from '../../src/config/retry/fixed-count-retry-strategy';
-import {NoopMomentoLoggerFactory} from '../../src/config/logging/noop-momento-logger';
 import {DefaultMomentoLoggerFactory} from '../../src';
 
 describe('configuration.ts', () => {
@@ -26,21 +25,6 @@ describe('configuration.ts', () => {
     loggerFactory: testLoggerFactory,
     retryStrategy: testRetryStrategy,
     transportStrategy: testTransportStrategy,
-  });
-
-  it('should support overriding logger options', () => {
-    const newLoggerFactory = new NoopMomentoLoggerFactory();
-    const configWithNewLoggerOptions =
-      testConfiguration.withLoggerFactory(newLoggerFactory);
-    expect(configWithNewLoggerOptions.getLoggerFactory()).toEqual(
-      newLoggerFactory
-    );
-    expect(configWithNewLoggerOptions.getRetryStrategy()).toEqual(
-      testRetryStrategy
-    );
-    expect(configWithNewLoggerOptions.getTransportStrategy()).toEqual(
-      testTransportStrategy
-    );
   });
 
   it('should support overriding retry strategy', () => {


### PR DESCRIPTION
I had forgotten a hard-fought lesson that I learned in the .NET
SDK (which also needs this fix): the pre-built configurations
will often pass the loggerFactory around to the constructors
of other components that they instantiate, such as the RetryInterceptor.

If this happens, and then we allow the user to override the loggerFactory
on the config with a new one, we can end up in a state where the original
factory is being used for some components and the new one for other
components.  For a short time I attempted to reconcile this by trying
to keep track of all of the places where the loggerFactory had been
referenced and then trying to update those as well, but it was a big
mess that wasn't guaranteed to work so we decided that was a bad path
to go down.

Hence, it is necessary for users to specify the one true loggerFactory
(or use the default one) at the time when they construct their
Configuration object.  To that end this commit removes the function
that would allow them to override it.
