### PR TITLE
chore: Stop the credential provider toString from including the cred

### DIFF
--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -76,6 +76,10 @@ export class StringMomentoTokenProvider implements CredentialProvider {
   getControlEndpoint(): string {
     return this.controlEndpoint;
   }
+
+  public toString(): string {
+    return `Control endpoint: ${this.getControlEndpoint()} Cache endpoint: ${this.getCacheEndpoint()}`;
+  }
 }
 
 export interface EnvMomentoTokenProviderProps extends CredentialProviderProps {
@@ -91,6 +95,7 @@ export interface EnvMomentoTokenProviderProps extends CredentialProviderProps {
  * @class EnvMomentoTokenProvider
  */
 export class EnvMomentoTokenProvider extends StringMomentoTokenProvider {
+  environmentVariableName: string;
   /**
    * @param {EnvMomentoTokenProviderProps} props configuration options for the token provider
    */
@@ -106,5 +111,12 @@ export class EnvMomentoTokenProvider extends StringMomentoTokenProvider {
       controlEndpoint: props.controlEndpoint,
       cacheEndpoint: props.cacheEndpoint,
     });
+    this.environmentVariableName = props.environmentVariableName;
+  }
+
+  public toString(): string {
+    return `Token environment variable: ${
+      this.environmentVariableName
+    } Control endpoint: ${this.getControlEndpoint()} Cache endpoint: ${this.getCacheEndpoint()}`;
   }
 }

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -1,4 +1,5 @@
 import {decodeJwt} from '../internal/utils/jwt';
+import {fromEntries} from '../internal/utils/object';
 
 /**
  * Encapsulates arguments for instantiating an EnvMomentoTokenProvider
@@ -37,6 +38,21 @@ export interface CredentialProvider {
   getCacheEndpoint(): string;
 }
 
+abstract class CredentialProviderBase implements CredentialProvider {
+  abstract getAuthToken(): string;
+
+  abstract getCacheEndpoint(): string;
+
+  abstract getControlEndpoint(): string;
+
+  valueOf(): object {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const entries = Object.entries(this).filter(([k]) => k !== 'authToken');
+    const clone = fromEntries(entries);
+    return clone.valueOf();
+  }
+}
+
 export interface StringMomentoTokenProviderProps
   extends CredentialProviderProps {
   /**
@@ -50,7 +66,7 @@ export interface StringMomentoTokenProviderProps
  * @export
  * @class StringMomentoTokenProvider
  */
-export class StringMomentoTokenProvider implements CredentialProvider {
+export class StringMomentoTokenProvider extends CredentialProviderBase {
   private readonly authToken: string;
   private readonly controlEndpoint: string;
   private readonly cacheEndpoint: string;
@@ -59,6 +75,7 @@ export class StringMomentoTokenProvider implements CredentialProvider {
    * @param {StringMomentoTokenProviderProps} props configuration options for the token provider
    */
   constructor(props: StringMomentoTokenProviderProps) {
+    super();
     this.authToken = props.authToken;
     const claims = decodeJwt(props.authToken);
     this.controlEndpoint = props.controlEndpoint ?? claims.cp;
@@ -75,10 +92,6 @@ export class StringMomentoTokenProvider implements CredentialProvider {
 
   getControlEndpoint(): string {
     return this.controlEndpoint;
-  }
-
-  public toString(): string {
-    return `Control endpoint: ${this.getControlEndpoint()} Cache endpoint: ${this.getCacheEndpoint()}`;
   }
 }
 
@@ -112,11 +125,5 @@ export class EnvMomentoTokenProvider extends StringMomentoTokenProvider {
       cacheEndpoint: props.cacheEndpoint,
     });
     this.environmentVariableName = props.environmentVariableName;
-  }
-
-  public toString(): string {
-    return `Token environment variable: ${
-      this.environmentVariableName
-    } Control endpoint: ${this.getControlEndpoint()} Cache endpoint: ${this.getCacheEndpoint()}`;
   }
 }

--- a/src/internal/utils/object.ts
+++ b/src/internal/utils/object.ts
@@ -1,0 +1,3 @@
+export function fromEntries(entries: [string, unknown][]): object {
+  return entries.reduce((acc, [key, value]) => ({...acc, [key]: value}), {});
+}


### PR DESCRIPTION
Override the valueOf method in the credential providers to prevent them from including the credential in the returned value.