### PR TITLE
feat: provide factory functions for instantiating CredentialsProviders

### DIFF
--- a/integration/integration-setup.ts
+++ b/integration/integration-setup.ts
@@ -4,10 +4,10 @@ import {
   CreateCache,
   Configurations,
   DeleteCache,
-  EnvMomentoTokenProvider,
   CollectionTtl,
   MomentoErrorCode,
   SimpleCacheClient,
+  CredentialProvider,
 } from '../src';
 import {
   IResponseError,
@@ -47,7 +47,7 @@ export async function WithCache(
 
 export const CacheClientProps: SimpleCacheClientProps = {
   configuration: Configurations.Laptop.latest(),
-  credentialProvider: new EnvMomentoTokenProvider({
+  credentialProvider: CredentialProvider.fromEnvironmentVariable({
     environmentVariableName: 'TEST_AUTH_TOKEN',
   }),
   defaultTtlSeconds: 1111,

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -21,21 +21,33 @@ interface CredentialProviderProps {
  * @export
  * @interface CredentialProvider
  */
-export interface CredentialProvider {
+export abstract class CredentialProvider {
   /**
    * @returns {string} Auth token provided by user, required to authenticate with the service
    */
-  getAuthToken(): string;
+  abstract getAuthToken(): string;
 
   /**
    * @returns {string} The host which the Momento client will connect to for Momento control plane operations
    */
-  getControlEndpoint(): string;
+  abstract getControlEndpoint(): string;
 
   /**
    * @returns {string} The host which the Momento client will connect to for Momento data plane operations
    */
-  getCacheEndpoint(): string;
+  abstract getCacheEndpoint(): string;
+
+  static fromEnvironmentVariable(
+    props: EnvMomentoTokenProviderProps
+  ): CredentialProvider {
+    return new EnvMomentoTokenProvider(props);
+  }
+
+  static fromString(
+    props: StringMomentoTokenProviderProps
+  ): CredentialProvider {
+    return new StringMomentoTokenProvider(props);
+  }
 }
 
 abstract class CredentialProviderBase implements CredentialProvider {

--- a/test/auth/credential-provider.test.ts
+++ b/test/auth/credential-provider.test.ts
@@ -1,7 +1,4 @@
-import {
-  StringMomentoTokenProvider,
-  EnvMomentoTokenProvider,
-} from '../../src/auth/credential-provider';
+import {CredentialProvider} from '../../src/auth/credential-provider';
 
 const testToken =
   'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmb29Abm90LmEuZG9tYWluIiwiY3AiOiJjb250cm9sLXBsYW5lLWVuZHBvaW50Lm5vdC5hLmRvbWFpbiIsImMiOiJjYWNoZS1lbmRwb2ludC5ub3QuYS5kb21haW4ifQo.rtxfu4miBHQ1uptWJ2x3UiAwwJYcMeYIkkpXxUno_wIavg4h6YJStcbxk32NDBbmJkJS7mUw6MsvJNWaxfdPOw';
@@ -10,14 +7,14 @@ const testCacheEndpoint = 'cache-endpoint.not.a.domain';
 
 describe('StringMomentoTokenProvider', () => {
   it('parses a valid token', () => {
-    const authProvider = new StringMomentoTokenProvider({authToken: testToken});
+    const authProvider = CredentialProvider.fromString({authToken: testToken});
     expect(authProvider.getAuthToken()).toEqual(testToken);
     expect(authProvider.getControlEndpoint()).toEqual(testControlEndpoint);
     expect(authProvider.getCacheEndpoint()).toEqual(testCacheEndpoint);
   });
 
   it('supports overriding control endpoint', () => {
-    const authProvider = new StringMomentoTokenProvider({
+    const authProvider = CredentialProvider.fromString({
       authToken: testToken,
       controlEndpoint: 'foo',
     });
@@ -27,7 +24,7 @@ describe('StringMomentoTokenProvider', () => {
   });
 
   it('supports overriding cache endpoint', () => {
-    const authProvider = new StringMomentoTokenProvider({
+    const authProvider = CredentialProvider.fromString({
       authToken: testToken,
       cacheEndpoint: 'foo',
     });
@@ -42,7 +39,7 @@ describe('EnvMomentoTokenProvider', () => {
   process.env[testEnvVarName] = testToken;
 
   it('parses a valid token', () => {
-    const authProvider = new EnvMomentoTokenProvider({
+    const authProvider = CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: testEnvVarName,
     });
     expect(authProvider.getAuthToken()).toEqual(testToken);
@@ -51,7 +48,7 @@ describe('EnvMomentoTokenProvider', () => {
   });
 
   it('supports overriding control endpoint', () => {
-    const authProvider = new EnvMomentoTokenProvider({
+    const authProvider = CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: testEnvVarName,
       controlEndpoint: 'foo',
     });
@@ -61,7 +58,7 @@ describe('EnvMomentoTokenProvider', () => {
   });
 
   it('supports overriding cache endpoint', () => {
-    const authProvider = new EnvMomentoTokenProvider({
+    const authProvider = CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: testEnvVarName,
       cacheEndpoint: 'foo',
     });


### PR DESCRIPTION
This commit adds some static factory functions for instantiating
CredentialsProviders, to make them a little more discoverable and
user-friendly.
