### PR TITLE
feat: Implement `hitOrElse` utility function on all hittable responses

### DIFF
--- a/integration/dictionary.test.ts
+++ b/integration/dictionary.test.ts
@@ -272,6 +272,24 @@ describe('Integration tests for dictionary operations', () => {
         expectedStringStringRecord
       );
       expect(hitResponse.valueRecord()).toEqual(expectedStringStringRecord);
+
+      const hitOrElseValueForHit = response.hitOrElse(
+        h => h.valueRecord(),
+        () => ({foo: 'FOO'})
+      );
+
+      expect(hitOrElseValueForHit).toEqual(expectedStringStringRecord);
+
+      const missResponse = await Momento.dictionaryFetch(
+        IntegrationTestCacheName,
+        'DoesNotExist'
+      );
+      expect(missResponse).toBeInstanceOf(CacheDictionaryFetch.Miss);
+      const hitOrElseValueForMiss = missResponse.hitOrElse(
+        h => h.valueRecord(),
+        () => ({foo: 'FOO'})
+      );
+      expect(hitOrElseValueForMiss).toEqual({foo: 'FOO'});
     });
 
     it('should provide value accessors for bytes fields with dictionaryFetch', async () => {
@@ -311,14 +329,17 @@ describe('Integration tests for dictionary operations', () => {
 
     it('should do nothing with dictionaryFetch if dictionary does not exist', async () => {
       const dictionaryName = v4();
-      let response = await Momento.dictionaryFetch(
+      const fetchResponse = await Momento.dictionaryFetch(
         IntegrationTestCacheName,
         dictionaryName
       );
-      expect(response).toBeInstanceOf(CacheDictionaryFetch.Miss);
-      response = await Momento.delete(IntegrationTestCacheName, dictionaryName);
-      expect(response).toBeInstanceOf(CacheDelete.Success);
-      response = await Momento.dictionaryFetch(
+      expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Miss);
+      const deleteResponse = await Momento.delete(
+        IntegrationTestCacheName,
+        dictionaryName
+      );
+      expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
+      const response = await Momento.dictionaryFetch(
         IntegrationTestCacheName,
         dictionaryName
       );
@@ -337,16 +358,19 @@ describe('Integration tests for dictionary operations', () => {
         ])
       );
 
-      let response = await Momento.dictionaryFetch(
+      const fetchResponse = await Momento.dictionaryFetch(
         IntegrationTestCacheName,
         dictionaryName
       );
-      expect(response).toBeInstanceOf(CacheDictionaryFetch.Hit);
+      expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Hit);
 
-      response = await Momento.delete(IntegrationTestCacheName, dictionaryName);
-      expect(response).toBeInstanceOf(CacheDelete.Success);
+      const deleteResponse = await Momento.delete(
+        IntegrationTestCacheName,
+        dictionaryName
+      );
+      expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
 
-      response = await Momento.dictionaryFetch(
+      const response = await Momento.dictionaryFetch(
         IntegrationTestCacheName,
         dictionaryName
       );

--- a/integration/dictionary.test.ts
+++ b/integration/dictionary.test.ts
@@ -538,6 +538,24 @@ describe('Integration tests for dictionary operations', () => {
       expect(expectedRecordStringBytes).toEqual(
         hitResponse.valueRecordStringUint8Array()
       );
+
+      const hitOrElseHitResult = getResponse.hitOrElse(
+        h => h.valueRecord(),
+        () => ({foo: 'FOO'})
+      );
+      expect(hitOrElseHitResult).toEqual(expectedRecordStringString);
+
+      const anotherMissResponse = await Momento.dictionaryGetFields(
+        IntegrationTestCacheName,
+        'DoesNotExist',
+        [field1, field2, field3]
+      );
+      expect(anotherMissResponse).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+      const hitOrElseMissResult = anotherMissResponse.hitOrElse(
+        h => h.valueRecord(),
+        () => ({foo: 'FOO'})
+      );
+      expect(hitOrElseMissResult).toEqual({foo: 'FOO'});
     });
 
     it('should dictionarySetField/dictionaryGetFields with Uint8Array fields/values', async () => {
@@ -1116,6 +1134,24 @@ describe('Integration tests for dictionary operations', () => {
       if (getResponse instanceof CacheDictionaryGetField.Hit) {
         expect(getResponse.valueString()).toEqual(value);
       }
+
+      const hitOrElseHitResult = getResponse.hitOrElse(
+        h => h.valueString(),
+        () => 'FOO'
+      );
+      expect(hitOrElseHitResult).toEqual(value);
+
+      const missResponse = await Momento.dictionaryGetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        'DoesNotExist'
+      );
+      expect(missResponse).toBeInstanceOf(CacheDictionaryGetField.Miss);
+      const hitOrElseMissResult = missResponse.hitOrElse(
+        h => h.valueString(),
+        () => 'FOO'
+      );
+      expect(hitOrElseMissResult).toEqual('FOO');
     });
 
     it('should set/get a dictionary with string field and Uint8Array value', async () => {

--- a/integration/get-set-delete.test.ts
+++ b/integration/get-set-delete.test.ts
@@ -42,6 +42,23 @@ describe('get/set/delete', () => {
     if (getResponse instanceof CacheGet.Hit) {
       expect(getResponse.valueString()).toEqual(cacheValue);
     }
+
+    const hitOrElseHitResult = getResponse.hitOrElse(
+      h => h.valueString(),
+      () => 'FOO'
+    );
+    expect(hitOrElseHitResult).toEqual(cacheValue);
+
+    const missResponse = await Momento.get(
+      IntegrationTestCacheName,
+      'DoesNotExist'
+    );
+    expect(missResponse).toBeInstanceOf(CacheGet.Miss);
+    const hitOrElseMissResult = missResponse.hitOrElse(
+      h => h.valueString(),
+      () => 'FOO'
+    );
+    expect(hitOrElseMissResult).toEqual('FOO');
   });
 
   it('should set and get bytes from cache', async () => {

--- a/integration/list.test.ts
+++ b/integration/list.test.ts
@@ -251,12 +251,32 @@ describe('lists', () => {
         valueString
       );
 
-      const respFetch = <CacheListFetch.Hit>(
-        await Momento.listFetch(IntegrationTestCacheName, listName)
+      const fetchResponse = await Momento.listFetch(
+        IntegrationTestCacheName,
+        listName
       );
-      expect(respFetch.valueListString()).toEqual([valueString]);
-      expect(respFetch.valueList()).toEqual([valueString]);
-      expect(respFetch.valueListUint8Array()).toEqual([valueBytes]);
+      expect(fetchResponse).toBeInstanceOf(CacheListFetch.Hit);
+      const hitResponse = fetchResponse as CacheListFetch.Hit;
+      expect(hitResponse.valueListString()).toEqual([valueString]);
+      expect(hitResponse.valueList()).toEqual([valueString]);
+      expect(hitResponse.valueListUint8Array()).toEqual([valueBytes]);
+
+      const hitOrElseHitResult = fetchResponse.hitOrElse(
+        h => h.valueList(),
+        () => ['FOO']
+      );
+      expect(hitOrElseHitResult).toEqual([valueString]);
+
+      const missResponse = await Momento.listFetch(
+        IntegrationTestCacheName,
+        'DoesNotExist'
+      );
+      expect(missResponse).toBeInstanceOf(CacheListFetch.Miss);
+      const hitOrElseMissResult = missResponse.hitOrElse(
+        h => h.valueList(),
+        () => ['FOO']
+      );
+      expect(hitOrElseMissResult).toEqual(['FOO']);
     });
   });
 
@@ -283,6 +303,23 @@ describe('lists', () => {
       const resp = await Momento.listLength(IntegrationTestCacheName, listName);
       expect(resp).toBeInstanceOf(CacheListLength.Hit);
       expect((resp as CacheListLength.Hit).length()).toEqual(values.length);
+
+      const hitOrElseHitResult = resp.hitOrElse(
+        h => h.length(),
+        () => 90210
+      );
+      expect(hitOrElseHitResult).toEqual(values.length);
+
+      const missResponse = await Momento.listLength(
+        IntegrationTestCacheName,
+        'DoesNotExist'
+      );
+      expect(missResponse).toBeInstanceOf(CacheListLength.Miss);
+      const hitOrElseMissResult = missResponse.hitOrElse(
+        h => h.length(),
+        () => 90210
+      );
+      expect(hitOrElseMissResult).toEqual(90210);
     });
   });
 
@@ -317,6 +354,23 @@ describe('lists', () => {
       expect((resp as CacheListPopBack.Hit).valueUint8Array()).toEqual(
         poppedBinary
       );
+
+      const hitOrElseHitResult = resp.hitOrElse(
+        h => h.valueString(),
+        () => 'FOO'
+      );
+      expect(hitOrElseHitResult).toEqual(poppedValue);
+
+      const missResponse = await Momento.listPopBack(
+        IntegrationTestCacheName,
+        'DoesNotExist'
+      );
+      expect(missResponse).toBeInstanceOf(CacheListPopBack.Miss);
+      const hitOrElseMissResult = missResponse.hitOrElse(
+        h => h.valueString(),
+        () => 'FOO'
+      );
+      expect(hitOrElseMissResult).toEqual('FOO');
     });
   });
 
@@ -353,6 +407,23 @@ describe('lists', () => {
       expect((resp as CacheListPopFront.Hit).valueUint8Array()).toEqual(
         poppedBinary
       );
+
+      const hitOrElseHitResult = resp.hitOrElse(
+        h => h.valueString(),
+        () => 'FOO'
+      );
+      expect(hitOrElseHitResult).toEqual(poppedValue);
+
+      const missResponse = await Momento.listPopFront(
+        IntegrationTestCacheName,
+        'DoesNotExist'
+      );
+      expect(missResponse).toBeInstanceOf(CacheListPopFront.Miss);
+      const hitOrElseMissResult = missResponse.hitOrElse(
+        h => h.valueString(),
+        () => 'FOO'
+      );
+      expect(hitOrElseMissResult).toEqual('FOO');
     });
   });
 

--- a/integration/set.test.ts
+++ b/integration/set.test.ts
@@ -249,6 +249,25 @@ describe('Integration Tests for operations on sets datastructure', () => {
     expect(hit.valueArray()).toContainAllValues(['lol', 'foo']);
     expect(hit.valueArrayString()).toBeArrayOfSize(2);
     expect(hit.valueArrayString()).toContainAllValues(['lol', 'foo']);
+
+    const hitOrElseHitResult = fetchResponse.hitOrElse(
+      h => h.valueArrayString(),
+      () => ['FOO']
+    );
+    expect(hitOrElseHitResult).toBeArrayOfSize(2);
+    expect(hitOrElseHitResult).toContainAllValues(['lol', 'foo']);
+
+    const missResponse = await Momento.setFetch(
+      IntegrationTestCacheName,
+      'DoesNotExist'
+    );
+    expect(missResponse).toBeInstanceOf(CacheSetFetch.Miss);
+    const hitOrElseMissResult = missResponse.hitOrElse(
+      h => h.valueArrayString(),
+      () => ['FOO']
+    );
+    expect(hitOrElseMissResult).toBeArrayOfSize(1);
+    expect(hitOrElseMissResult).toContainAllValues(['FOO']);
   });
   it('should succeed for addElements with duplicate elements', async () => {
     const setName = v4();

--- a/src/messages/responses/cache-dictionary-fetch.ts
+++ b/src/messages/responses/cache-dictionary-fetch.ts
@@ -9,8 +9,25 @@ import {TextDecoder} from 'util';
 import {cache_client} from '@gomomento/generated-types/dist/cacheclient';
 
 const TEXT_DECODER = new TextDecoder();
+const TEXT_ENCODER = new TextEncoder();
 
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public hitOrElse(fallback: () => Record<string, string>): Hit {
+    if (this instanceof Hit) {
+      return this;
+    }
+    const value: cache_client._DictionaryFieldValuePair[] = Object.entries(
+      fallback()
+    ).map(
+      entry =>
+        new cache_client._DictionaryFieldValuePair({
+          field: TEXT_ENCODER.encode(entry[0]),
+          value: TEXT_ENCODER.encode(entry[1]),
+        })
+    );
+    return new Hit(value);
+  }
+}
 
 class _Hit extends Response {
   private readonly items: cache_client._DictionaryFieldValuePair[];

--- a/src/messages/responses/cache-dictionary-fetch.ts
+++ b/src/messages/responses/cache-dictionary-fetch.ts
@@ -9,23 +9,13 @@ import {TextDecoder} from 'util';
 import {cache_client} from '@gomomento/generated-types/dist/cacheclient';
 
 const TEXT_DECODER = new TextDecoder();
-const TEXT_ENCODER = new TextEncoder();
 
 export abstract class Response extends ResponseBase {
-  public hitOrElse(fallback: () => Record<string, string>): Hit {
+  public hitOrElse<T>(valueFn: (hit: Hit) => T, fallback: () => T): T {
     if (this instanceof Hit) {
-      return this;
+      return valueFn(this);
     }
-    const value: cache_client._DictionaryFieldValuePair[] = Object.entries(
-      fallback()
-    ).map(
-      entry =>
-        new cache_client._DictionaryFieldValuePair({
-          field: TEXT_ENCODER.encode(entry[0]),
-          value: TEXT_ENCODER.encode(entry[1]),
-        })
-    );
-    return new Hit(value);
+    return fallback();
   }
 }
 

--- a/src/messages/responses/cache-dictionary-fetch.ts
+++ b/src/messages/responses/cache-dictionary-fetch.ts
@@ -11,11 +11,12 @@ import {cache_client} from '@gomomento/generated-types/dist/cacheclient';
 const TEXT_DECODER = new TextDecoder();
 
 export abstract class Response extends ResponseBase {
-  public hitOrElse<T>(valueFn: (hit: Hit) => T, fallback: () => T): T {
+  public hitOrElse<T>(hitFn: (h: Hit) => T, elseFn: () => T): T {
     if (this instanceof Hit) {
-      return valueFn(this);
+      return hitFn(this);
+    } else {
+      return elseFn();
     }
-    return fallback();
   }
 }
 

--- a/src/messages/responses/cache-dictionary-get-field.ts
+++ b/src/messages/responses/cache-dictionary-get-field.ts
@@ -27,11 +27,12 @@ export abstract class Response extends ResponseBase {
     return this.field;
   }
 
-  public hitOrElse(fallback: () => Uint8Array): Hit {
+  public hitOrElse<T>(hitFn: (h: Hit) => T, elseFn: () => T): T {
     if (this instanceof Hit) {
-      return this;
+      return hitFn(this);
+    } else {
+      return elseFn();
     }
-    return new Hit(fallback(), this.field);
   }
 }
 

--- a/src/messages/responses/cache-dictionary-get-field.ts
+++ b/src/messages/responses/cache-dictionary-get-field.ts
@@ -11,12 +11,34 @@ import {truncateString} from '../../internal/utils/display';
 
 const TEXT_DECODER = new TextDecoder();
 
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  protected readonly field: Uint8Array;
+
+  constructor(field: Uint8Array) {
+    super();
+    this.field = field;
+  }
+
+  public fieldString(): string {
+    return TEXT_DECODER.decode(this.field);
+  }
+
+  public fieldUint8Array(): Uint8Array {
+    return this.field;
+  }
+
+  public hitOrElse(fallback: () => Uint8Array): Hit {
+    if (this instanceof Hit) {
+      return this;
+    }
+    return new Hit(fallback(), this.field);
+  }
+}
 
 class _Hit extends Response {
   private readonly body: Uint8Array;
-  constructor(body: Uint8Array) {
-    super();
+  constructor(body: Uint8Array, field: Uint8Array) {
+    super(field);
     this.body = body;
   }
   /**
@@ -37,59 +59,26 @@ class _Hit extends Response {
   }
 }
 export class Hit extends ResponseHit(_Hit) {
-  private readonly field: Uint8Array;
-
   constructor(body: Uint8Array, field: Uint8Array) {
-    super(body);
-    this.field = field;
-  }
-
-  public fieldString(): string {
-    return TEXT_DECODER.decode(this.field);
-  }
-
-  public fieldUint8Array(): Uint8Array {
-    return this.field;
+    super(body, field);
   }
 }
 
 class _Miss extends Response {}
 export class Miss extends ResponseMiss(_Miss) {
-  private readonly field: Uint8Array;
-
   constructor(field: Uint8Array) {
-    super();
-    this.field = field;
-  }
-
-  public fieldString(): string {
-    return TEXT_DECODER.decode(this.field);
-  }
-
-  public fieldUint8Array(): Uint8Array {
-    return this.field;
+    super(field);
   }
 }
 
 class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
+  constructor(protected _innerException: SdkError, field: Uint8Array) {
+    super(field);
   }
 }
 
 export class Error extends ResponseError(_Error) {
-  private readonly field: Uint8Array;
-
   constructor(public _innerException: SdkError, field: Uint8Array) {
-    super(_innerException);
-    this.field = field;
-  }
-
-  public fieldString(): string {
-    return TEXT_DECODER.decode(this.field);
-  }
-
-  public fieldUint8Array(): Uint8Array {
-    return this.field;
+    super(_innerException, field);
   }
 }

--- a/src/messages/responses/cache-dictionary-get-fields.ts
+++ b/src/messages/responses/cache-dictionary-get-fields.ts
@@ -17,7 +17,15 @@ type CacheDictionaryGetFieldResponseType =
   | CacheDictionaryGetFieldResponse.Miss
   | CacheDictionaryGetFieldResponse.Error;
 
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public hitOrElse<T>(hitFn: (h: Hit) => T, elseFn: () => T): T {
+    if (this instanceof Hit) {
+      return hitFn(this);
+    } else {
+      return elseFn();
+    }
+  }
+}
 
 class _Hit extends Response {
   private readonly items: grpcCache._DictionaryGetResponse._DictionaryGetResponsePart[];

--- a/src/messages/responses/cache-get.ts
+++ b/src/messages/responses/cache-get.ts
@@ -1,5 +1,5 @@
 // older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
-import {TextDecoder} from 'util';
+import {TextDecoder, TextEncoder} from 'util';
 import {SdkError} from '../../errors/errors';
 import {
   ResponseBase,
@@ -10,8 +10,21 @@ import {
 import {truncateString} from '../../internal/utils/display';
 
 const TEXT_DECODER = new TextDecoder();
+const TEXT_ENCODER = new TextEncoder();
 
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public hitOrElse(fallback: () => Uint8Array | string): Hit {
+    if (this instanceof Hit) {
+      return this;
+    }
+    const value = fallback();
+    if (value instanceof Uint8Array) {
+      return new Hit(value);
+    } else {
+      return new Hit(TEXT_ENCODER.encode(value));
+    }
+  }
+}
 
 class _Hit extends Response {
   private readonly body: Uint8Array;

--- a/src/messages/responses/cache-get.ts
+++ b/src/messages/responses/cache-get.ts
@@ -1,5 +1,5 @@
 // older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
-import {TextDecoder, TextEncoder} from 'util';
+import {TextDecoder} from 'util';
 import {SdkError} from '../../errors/errors';
 import {
   ResponseBase,
@@ -10,18 +10,13 @@ import {
 import {truncateString} from '../../internal/utils/display';
 
 const TEXT_DECODER = new TextDecoder();
-const TEXT_ENCODER = new TextEncoder();
 
 export abstract class Response extends ResponseBase {
-  public hitOrElse(fallback: () => Uint8Array | string): Hit {
+  public hitOrElse<T>(hitFn: (h: Hit) => T, elseFn: () => T): T {
     if (this instanceof Hit) {
-      return this;
-    }
-    const value = fallback();
-    if (value instanceof Uint8Array) {
-      return new Hit(value);
+      return hitFn(this);
     } else {
-      return new Hit(TEXT_ENCODER.encode(value));
+      return elseFn();
     }
   }
 }

--- a/src/messages/responses/cache-list-fetch.ts
+++ b/src/messages/responses/cache-list-fetch.ts
@@ -10,7 +10,15 @@ import {truncateStringArray} from '../../internal/utils/display';
 
 const TEXT_DECODER = new TextDecoder();
 
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public hitOrElse<T>(hitFn: (h: Hit) => T, elseFn: () => T): T {
+    if (this instanceof Hit) {
+      return hitFn(this);
+    } else {
+      return elseFn();
+    }
+  }
+}
 
 class _Hit extends Response {
   private readonly _values: Uint8Array[];

--- a/src/messages/responses/cache-list-length.ts
+++ b/src/messages/responses/cache-list-length.ts
@@ -6,7 +6,15 @@ import {
   ResponseMiss,
 } from './response-base';
 
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public hitOrElse<T>(hitFn: (h: Hit) => T, elseFn: () => T): T {
+    if (this instanceof Hit) {
+      return hitFn(this);
+    } else {
+      return elseFn();
+    }
+  }
+}
 
 class _Hit extends Response {
   private readonly _length: number;

--- a/src/messages/responses/cache-list-pop-back.ts
+++ b/src/messages/responses/cache-list-pop-back.ts
@@ -11,7 +11,15 @@ import {truncateString} from '../../internal/utils/display';
 
 const TEXT_DECODER = new TextDecoder();
 
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public hitOrElse<T>(hitFn: (h: Hit) => T, elseFn: () => T): T {
+    if (this instanceof Hit) {
+      return hitFn(this);
+    } else {
+      return elseFn();
+    }
+  }
+}
 
 class _Hit extends Response {
   private readonly body: Uint8Array;

--- a/src/messages/responses/cache-list-pop-front.ts
+++ b/src/messages/responses/cache-list-pop-front.ts
@@ -11,7 +11,15 @@ import {truncateString} from '../../internal/utils/display';
 
 const TEXT_DECODER = new TextDecoder();
 
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public hitOrElse<T>(hitFn: (h: Hit) => T, elseFn: () => T): T {
+    if (this instanceof Hit) {
+      return hitFn(this);
+    } else {
+      return elseFn();
+    }
+  }
+}
 
 class _Hit extends Response {
   private readonly body: Uint8Array;

--- a/src/messages/responses/cache-set-fetch.ts
+++ b/src/messages/responses/cache-set-fetch.ts
@@ -10,7 +10,15 @@ import {truncateStringArray} from '../../internal/utils/display';
 
 const TEXT_DECODER = new TextDecoder();
 
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public hitOrElse<T>(hitFn: (h: Hit) => T, elseFn: () => T): T {
+    if (this instanceof Hit) {
+      return hitFn(this);
+    } else {
+      return elseFn();
+    }
+  }
+}
 
 class _Hit extends Response {
   private readonly elements: Uint8Array[];


### PR DESCRIPTION
Adds a utility function that makes it easier for users to bail if all they care about is the `Hit` response path.