### PR TITLE
chore: better link to CLI for getting auth token

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -5,7 +5,7 @@
 ### Requirements
 
 - Node version [14 or higher](https://nodejs.org/en/download/) is required
-- A Momento Auth Token is required, you can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli)
+- A Momento Auth Token is required, you can generate one using the [Momento CLI](https://docs.momentohq.com/getting-started)
 
 ### Examples
 


### PR DESCRIPTION
During our recent bug bash it was called out that the link to the
momento-cli for getting an auth token pointed to a fairly verbose
doc.  This commit changes the link to point to our getting started
page, where users can choose between the in-browser approach or
the approach of installing the CLI for their OS.
