### PR TITLE
chore: remove redundant string casts in examples

### DIFF
--- a/examples/advanced.ts
+++ b/examples/advanced.ts
@@ -77,7 +77,7 @@ async function setGetDeleteExample() {
 
   const getResponse = await momento.get(cacheName, cacheKey);
   if (getResponse instanceof CacheGet.Hit) {
-    console.log(`cache hit: ${String(getResponse.valueString())}`);
+    console.log(`cache hit: ${getResponse.valueString()}`);
   } else if (getResponse instanceof CacheGet.Miss) {
     console.log('cache miss');
   } else if (getResponse instanceof CacheGet.Error) {

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -33,7 +33,7 @@ async function main() {
 
   const getResponse = await momento.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
-    console.log(`cache hit: ${String(getResponse.valueString())}`);
+    console.log(`cache hit: ${getResponse.valueString()}`);
   } else if (getResponse instanceof CacheGet.Miss) {
     console.log('cache miss');
   } else if (getResponse instanceof CacheGet.Error) {


### PR DESCRIPTION
This was called out during the recent bug bash.
