### PR TITLE
chore: change wording of log message when constructing client

### DIFF
--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -80,7 +80,7 @@ export class SimpleCacheClient {
    */
   constructor(props: SimpleCacheClientProps) {
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
-    this.logger.info('Instantiating Momento SimpleCacheClient');
+    this.logger.info('Creating Momento SimpleCacheClient');
     this.configuration = props.configuration;
     this.credentialProvider = props.credentialProvider;
 


### PR DESCRIPTION
Feedback from the bug bash was that using the word "Creating"
would be better than "Instantiating".
