### PR TITLE
chore: update examples to 1.1, use static pre-built configs

### DIFF
--- a/examples/advanced.ts
+++ b/examples/advanced.ts
@@ -22,7 +22,7 @@ const loggerFactory: MomentoLoggerFactory = new DefaultMomentoLoggerFactory();
 const logger = loggerFactory.getLogger('AdvancedExample');
 
 const momento = new SimpleCacheClient({
-  configuration: Configurations.Laptop.latest(loggerFactory),
+  configuration: Configurations.Laptop.v1(loggerFactory),
   credentialProvider: CredentialProvider.fromEnvironmentVariable({
     environmentVariableName: 'MOMENTO_AUTH_TOKEN',
   }),

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -9,7 +9,7 @@ import {
 
 async function main() {
   const momento = new SimpleCacheClient({
-    configuration: Configurations.Laptop.latest(),
+    configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
     }),

--- a/examples/dictionary.ts
+++ b/examples/dictionary.ts
@@ -24,7 +24,7 @@ const loggerFactory: MomentoLoggerFactory = new DefaultMomentoLoggerFactory();
 
 const defaultTtl = 60;
 const momento = new SimpleCacheClient({
-  configuration: Configurations.Laptop.latest(loggerFactory),
+  configuration: Configurations.Laptop.v1(loggerFactory),
   credentialProvider: credentialsProvider,
   defaultTtlSeconds: defaultTtl,
 });

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -72,7 +72,7 @@ class BasicLoadGen {
 
   async run(): Promise<void> {
     const momento = new SimpleCacheClient({
-      configuration: Configurations.Laptop.latest(
+      configuration: Configurations.Laptop.v1(
         this.loggerFactory
       ).withClientTimeoutMillis(this.options.requestTimeoutMs),
       credentialProvider: new EnvMomentoTokenProvider({

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@gomomento/generated-types": "0.32.1",
-        "@gomomento/sdk": "1.0.0",
+        "@gomomento/sdk": "1.1.0",
         "@grpc/grpc-js": "1.7.3",
         "hdr-histogram-js": "3.0.0",
         "node-fetch": "2.6.7",
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.0.0.tgz",
-      "integrity": "sha512-gUKB8SfNaf7lSOwCv9gbTFkkUCf3XCOTB24ga3lzju6ltVD+AIpVMGZ8cF7yEfKRPbgU52pcDRj8r9MSwX6XSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.1.0.tgz",
+      "integrity": "sha512-0RL9G4vAmJ8+fODnIK/xpvQrwr85EsfwGz2HbC1IBfXpa7xlFTd2lA3ES/SouF23KNphoFLEsYikgCPTdji2Ag==",
       "dependencies": {
         "@gomomento/generated-types": "0.32.1",
         "@grpc/grpc-js": "1.7.3",
@@ -3439,9 +3439,9 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.0.0.tgz",
-      "integrity": "sha512-gUKB8SfNaf7lSOwCv9gbTFkkUCf3XCOTB24ga3lzju6ltVD+AIpVMGZ8cF7yEfKRPbgU52pcDRj8r9MSwX6XSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.1.0.tgz",
+      "integrity": "sha512-0RL9G4vAmJ8+fODnIK/xpvQrwr85EsfwGz2HbC1IBfXpa7xlFTd2lA3ES/SouF23KNphoFLEsYikgCPTdji2Ag==",
       "requires": {
         "@gomomento/generated-types": "0.32.1",
         "@grpc/grpc-js": "1.7.3",

--- a/examples/package.json
+++ b/examples/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@gomomento/generated-types": "0.32.1",
-    "@gomomento/sdk": "1.0.0",
+    "@gomomento/sdk": "1.1.0",
     "@grpc/grpc-js": "1.7.3",
     "hdr-histogram-js": "3.0.0",
     "node-fetch": "2.6.7",


### PR DESCRIPTION
This commit updates us the examples to 1.1, and uses the
new v1 versions of the pre-built config objects rather than
the `latest()` versions.
