### PR TITLE
chore: add test coverage for set operation with ttl

### DIFF
--- a/integration/get-set-delete.test.ts
+++ b/integration/get-set-delete.test.ts
@@ -174,21 +174,6 @@ describe('get/set/delete', () => {
     }
   });
 
-  it('should return INVALID_ARGUMENT_ERROR for invalid ttl when set with byte key/value', async () => {
-    const setResponse = await Momento.set(
-      IntegrationTestCacheName,
-      new TextEncoder().encode(v4()),
-      new TextEncoder().encode(v4()),
-      {ttl: -1}
-    );
-    expect(setResponse).toBeInstanceOf(CacheSet.Error);
-    if (setResponse instanceof CacheSet.Error) {
-      expect(setResponse.errorCode()).toEqual(
-        MomentoErrorCode.INVALID_ARGUMENT_ERROR
-      );
-    }
-  });
-
   it('should set string key/value with valid ttl and get successfully', async () => {
     const cacheKey = v4();
     const cacheValue = v4();
@@ -203,23 +188,6 @@ describe('get/set/delete', () => {
     const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
     if (getResponse instanceof CacheGet.Hit) {
       expect(getResponse.valueString()).toEqual(cacheValue);
-    }
-  });
-
-  it('should set byte key/value with valid ttl and get successfully', async () => {
-    const cacheKey = new TextEncoder().encode(v4());
-    const cacheValue = new TextEncoder().encode(v4());
-    const setResponse = await Momento.set(
-      IntegrationTestCacheName,
-      cacheKey,
-      cacheValue,
-      {ttl: 15}
-    );
-    expect(setResponse).toBeInstanceOf(CacheSet.Success);
-
-    const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-    if (getResponse instanceof CacheGet.Hit) {
-      expect(getResponse.valueUint8Array()).toEqual(cacheValue);
     }
   });
 

--- a/integration/get-set-delete.test.ts
+++ b/integration/get-set-delete.test.ts
@@ -14,7 +14,7 @@ import {
   ItBehavesLikeItValidatesCacheName,
   WithCache,
 } from './integration-setup';
-import {sleep} from "../src/internal/utils/sleep";
+import {sleep} from '../src/internal/utils/sleep';
 
 const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
 

--- a/integration/get-set-delete.test.ts
+++ b/integration/get-set-delete.test.ts
@@ -14,6 +14,7 @@ import {
   ItBehavesLikeItValidatesCacheName,
   WithCache,
 } from './integration-setup';
+import {sleep} from "../src/internal/utils/sleep";
 
 const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
 
@@ -156,5 +157,84 @@ describe('get/set/delete', () => {
     expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
     const getMiss = await Momento.get(IntegrationTestCacheName, cacheKey);
     expect(getMiss).toBeInstanceOf(CacheGet.Miss);
+  });
+
+  it('should return INVALID_ARGUMENT_ERROR for invalid ttl when set with string key/value', async () => {
+    const setResponse = await Momento.set(
+      IntegrationTestCacheName,
+      v4(),
+      v4(),
+      {ttl: -1}
+    );
+    expect(setResponse).toBeInstanceOf(CacheSet.Error);
+    if (setResponse instanceof CacheSet.Error) {
+      expect(setResponse.errorCode()).toEqual(
+        MomentoErrorCode.INVALID_ARGUMENT_ERROR
+      );
+    }
+  });
+
+  it('should return INVALID_ARGUMENT_ERROR for invalid ttl when set with byte key/value', async () => {
+    const setResponse = await Momento.set(
+      IntegrationTestCacheName,
+      new TextEncoder().encode(v4()),
+      new TextEncoder().encode(v4()),
+      {ttl: -1}
+    );
+    expect(setResponse).toBeInstanceOf(CacheSet.Error);
+    if (setResponse instanceof CacheSet.Error) {
+      expect(setResponse.errorCode()).toEqual(
+        MomentoErrorCode.INVALID_ARGUMENT_ERROR
+      );
+    }
+  });
+
+  it('should set string key/value with valid ttl and get successfully', async () => {
+    const cacheKey = v4();
+    const cacheValue = v4();
+    const setResponse = await Momento.set(
+      IntegrationTestCacheName,
+      cacheKey,
+      cacheValue,
+      {ttl: 15}
+    );
+    expect(setResponse).toBeInstanceOf(CacheSet.Success);
+
+    const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+    if (getResponse instanceof CacheGet.Hit) {
+      expect(getResponse.valueString()).toEqual(cacheValue);
+    }
+  });
+
+  it('should set byte key/value with valid ttl and get successfully', async () => {
+    const cacheKey = new TextEncoder().encode(v4());
+    const cacheValue = new TextEncoder().encode(v4());
+    const setResponse = await Momento.set(
+      IntegrationTestCacheName,
+      cacheKey,
+      cacheValue,
+      {ttl: 15}
+    );
+    expect(setResponse).toBeInstanceOf(CacheSet.Success);
+
+    const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+    if (getResponse instanceof CacheGet.Hit) {
+      expect(getResponse.valueUint8Array()).toEqual(cacheValue);
+    }
+  });
+
+  it('should set with valid ttl and should return miss when ttl is expired', async () => {
+    const cacheKey = v4();
+    const setResponse = await Momento.set(
+      IntegrationTestCacheName,
+      cacheKey,
+      v4(),
+      {ttl: 1}
+    );
+    expect(setResponse).toBeInstanceOf(CacheSet.Success);
+    await sleep(3000);
+
+    const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+    expect(getResponse).toBeInstanceOf(CacheGet.Miss);
   });
 });


### PR DESCRIPTION
Added several tests for `set` operation with `options {ttl: some_ttl}` to make sure ttl works as expected.
I referenced the tests in our .NET SDK: https://github.com/momentohq/client-sdk-dotnet/blob/main/tests/Integration/Momento.Sdk.Tests/SimpleCacheDataTest.cs

Closes #239 