### PR TITLE
feat: use call options for sorted set fetch, including order

### DIFF
--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -47,6 +47,7 @@ import {version} from '../../package.json';
 import {IdleGrpcClientWrapper} from './grpc/idle-grpc-client-wrapper';
 import {GrpcClientWrapper} from './grpc/grpc-client-wrapper';
 import {normalizeSdkError} from '../errors/error-utils';
+import {SortedSetOrder} from '../utils/cache-call-options';
 import {
   validateCacheName,
   validateDictionaryName,
@@ -1718,7 +1719,8 @@ export class CacheClient {
   public async sortedSetFetchByIndex(
     cacheName: string,
     sortedSetName: string,
-    startIndex?: number,
+    order: SortedSetOrder,
+    startIndex: number,
     endIndex?: number
   ): Promise<CacheSortedSetFetch.Response> {
     try {
@@ -1727,15 +1729,18 @@ export class CacheClient {
     } catch (err) {
       return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
     }
+
     this.logger.trace(
-      "Issuing 'sortedSetFetchByIndex' request; startIndex: %s, endIndex : %s",
-      startIndex?.toString() ?? 'null',
-      endIndex?.toString() ?? 'null'
+      "Issuing 'sortedSetFetchByIndex' request; startIndex: %s, endIndex : %s, order: %s",
+      startIndex.toString() ?? 'null',
+      endIndex?.toString() ?? 'null',
+      order.toString()
     );
 
     const result = await this.sendSortedSetFetchByIndex(
       cacheName,
       this.convert(sortedSetName),
+      order,
       startIndex,
       endIndex
     );
@@ -1749,7 +1754,8 @@ export class CacheClient {
   private async sendSortedSetFetchByIndex(
     cacheName: string,
     sortedSetName: Uint8Array,
-    startIndex?: number,
+    order: SortedSetOrder,
+    startIndex: number,
     endIndex?: number
   ): Promise<CacheSortedSetFetch.Response> {
     const by_index = new grpcCache._SortedSetFetchRequest._ByIndex();
@@ -1764,9 +1770,14 @@ export class CacheClient {
       by_index.unbounded_end = new grpcCache._Unbounded();
     }
 
+    const protoBufOrder =
+      order === SortedSetOrder.Descending
+        ? grpcCache._SortedSetFetchRequest.Order.DESCENDING
+        : grpcCache._SortedSetFetchRequest.Order.ASCENDING;
+
     const request = new grpcCache._SortedSetFetchRequest({
       set_name: sortedSetName,
-      order: grpcCache._SortedSetFetchRequest.Order.ASCENDING,
+      order: protoBufOrder,
       with_scores: true,
       by_index: by_index,
     });

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -47,6 +47,8 @@ import {
   CollectionCallOptions,
   FrontTruncatableCallOptions,
   ScalarCallOptions,
+  SortedSetFetchByIndexCallOptions,
+  SortedSetOrder,
 } from './utils/cache-call-options';
 
 // Type aliases to differentiate the different methods' optional arguments.
@@ -63,6 +65,7 @@ type DictionarySetFieldsOptions = CollectionCallOptions;
 type DictionaryIncrementOptions = CollectionCallOptions;
 type IncrementOptions = ScalarCallOptions;
 type SortedSetPutValueOptions = CollectionCallOptions;
+type SortedSetFetchByIndexOptions = SortedSetFetchByIndexCallOptions;
 
 /**
  * Momento Simple Cache Client.
@@ -872,8 +875,13 @@ export class SimpleCacheClient {
    *
    * @param {string} cacheName - The cache containing the sorted set.
    * @param {string} sortedSetName - The sorted set to fetch from.
-   * @param {number} startIndex - The index of the first element to return. If omitted, defaults to 0.
-   * @param {number} endIndex - The index of the last element to return. If omitted, defaults to end of the sorted set.
+   * @param {SortedSetFetchByIndexOptions} options
+   * @param {number} [options.startIndex] - The index of the first element to
+   * fetch. Defaults to 0.
+   * @param {number} [options.endIndex] - The index of the last element to fetch.
+   * Defaults to null, which fetches up until and including the last element.
+   * @param {SortedSetOrder} [options.order] - The order to fetch the elements in.
+   * Defaults to ascending.
    * @returns {Promise<CacheSortedSetFetch.Response>}
    * {@link CacheSortedSetFetch.Hit} containing the requested elements when found.
    * {@link CacheSortedSetFetch.Miss} when the sorted set does not exist.
@@ -882,15 +890,15 @@ export class SimpleCacheClient {
   public async sortedSetFetchByIndex(
     cacheName: string,
     sortedSetName: string,
-    startIndex?: number,
-    endIndex?: number
+    options?: SortedSetFetchByIndexOptions
   ): Promise<CacheSortedSetFetch.Response> {
     const client = this.getNextDataClient();
     return await client.sortedSetFetchByIndex(
       cacheName,
       sortedSetName,
-      startIndex,
-      endIndex
+      options?.order ?? SortedSetOrder.Ascending,
+      options?.startIndex ?? 0,
+      options?.endIndex
     );
   }
 

--- a/src/utils/cache-call-options.ts
+++ b/src/utils/cache-call-options.ts
@@ -27,3 +27,14 @@ export interface BackTruncatableCallOptions extends CollectionCallOptions {
    */
   truncateBackToSize?: number;
 }
+
+export enum SortedSetOrder {
+  Ascending = 'ASC',
+  Descending = 'DESC',
+}
+
+export interface SortedSetFetchByIndexCallOptions {
+  startIndex?: number;
+  endIndex?: number;
+  order?: SortedSetOrder;
+}


### PR DESCRIPTION
For `sortedSetFetchByInde`: refactors the start and index index to be optional and part of call options. Also adds `order` to the call options.