### PR TITLE
feat: implement sorted set fetch by score

### DIFF
--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -1763,9 +1763,9 @@ export class CacheClient {
   ): Promise<CacheSortedSetFetch.Response> {
     const by_index = new grpcCache._SortedSetFetchRequest._ByIndex();
     if (startIndex) {
-      by_index['inclusive_start_index'] = startIndex;
+      by_index.inclusive_start_index = startIndex;
     } else {
-      by_index['unbounded_start'] = new grpcCache._Unbounded();
+      by_index.unbounded_start = new grpcCache._Unbounded();
     }
     if (endIndex) {
       by_index.exclusive_end_index = endIndex;

--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -47,6 +47,7 @@ import {version} from '../../package.json';
 import {IdleGrpcClientWrapper} from './grpc/idle-grpc-client-wrapper';
 import {GrpcClientWrapper} from './grpc/grpc-client-wrapper';
 import {normalizeSdkError} from '../errors/error-utils';
+import {SortedSetOrder} from '../utils/cache-call-options';
 import {
   validateCacheName,
   validateDictionaryName,
@@ -1718,7 +1719,8 @@ export class CacheClient {
   public async sortedSetFetchByIndex(
     cacheName: string,
     sortedSetName: string,
-    startIndex?: number,
+    order: SortedSetOrder,
+    startIndex: number,
     endIndex?: number
   ): Promise<CacheSortedSetFetch.Response> {
     try {
@@ -1727,15 +1729,18 @@ export class CacheClient {
     } catch (err) {
       return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
     }
+
     this.logger.trace(
-      "Issuing 'sortedSetFetchByIndex' request; startIndex: %s, endIndex : %s",
-      startIndex?.toString() ?? 'null',
-      endIndex?.toString() ?? 'null'
+      "Issuing 'sortedSetFetchByIndex' request; startIndex: %s, endIndex : %s, order: %s",
+      startIndex.toString() ?? 'null',
+      endIndex?.toString() ?? 'null',
+      order.toString()
     );
 
     const result = await this.sendSortedSetFetchByIndex(
       cacheName,
       this.convert(sortedSetName),
+      order,
       startIndex,
       endIndex
     );
@@ -1749,7 +1754,8 @@ export class CacheClient {
   private async sendSortedSetFetchByIndex(
     cacheName: string,
     sortedSetName: Uint8Array,
-    startIndex?: number,
+    order: SortedSetOrder,
+    startIndex: number,
     endIndex?: number
   ): Promise<CacheSortedSetFetch.Response> {
     const by_index = new grpcCache._SortedSetFetchRequest._ByIndex();
@@ -1764,9 +1770,14 @@ export class CacheClient {
       by_index.unbounded_end = new grpcCache._Unbounded();
     }
 
+    const protoBufOrder =
+      order === SortedSetOrder.Descending
+        ? grpcCache._SortedSetFetchRequest.Order.DESCENDING
+        : grpcCache._SortedSetFetchRequest.Order.ASCENDING;
+
     const request = new grpcCache._SortedSetFetchRequest({
       set_name: sortedSetName,
-      order: grpcCache._SortedSetFetchRequest.Order.ASCENDING,
+      order: protoBufOrder,
       with_scores: true,
       by_index: by_index,
     });

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -47,6 +47,8 @@ import {
   CollectionCallOptions,
   FrontTruncatableCallOptions,
   ScalarCallOptions,
+  SortedSetFetchByIndexCallOptions,
+  SortedSetOrder,
 } from './utils/cache-call-options';
 
 // Type aliases to differentiate the different methods' optional arguments.
@@ -63,6 +65,7 @@ type DictionarySetFieldsOptions = CollectionCallOptions;
 type DictionaryIncrementOptions = CollectionCallOptions;
 type IncrementOptions = ScalarCallOptions;
 type SortedSetPutValueOptions = CollectionCallOptions;
+type SortedSetFetchByIndexOptions = SortedSetFetchByIndexCallOptions;
 
 /**
  * Momento Simple Cache Client.
@@ -872,8 +875,13 @@ export class SimpleCacheClient {
    *
    * @param {string} cacheName - The cache containing the sorted set.
    * @param {string} sortedSetName - The sorted set to fetch from.
-   * @param {number} startIndex - The index of the first element to return. If omitted, defaults to 0.
-   * @param {number} endIndex - The index of the last element to return. If omitted, defaults to end of the sorted set.
+   * @param {SortedSetFetchByIndexOptions} options
+   * @param {number} [options.startIndex] - The index of the first element to
+   * fetch. Defaults to 0.
+   * @param {number} [options.endIndex] - The index of the last element to fetch.
+   * Defaults to null, which fetches up until and including the last element.
+   * @param {SortedSetOrder} [options.order] - The order to fetch the elements in.
+   * Defaults to ascending.
    * @returns {Promise<CacheSortedSetFetch.Response>}
    * {@link CacheSortedSetFetch.Hit} containing the requested elements when found.
    * {@link CacheSortedSetFetch.Miss} when the sorted set does not exist.
@@ -882,15 +890,15 @@ export class SimpleCacheClient {
   public async sortedSetFetchByIndex(
     cacheName: string,
     sortedSetName: string,
-    startIndex?: number,
-    endIndex?: number
+    options?: SortedSetFetchByIndexOptions
   ): Promise<CacheSortedSetFetch.Response> {
     const client = this.getNextDataClient();
     return await client.sortedSetFetchByIndex(
       cacheName,
       sortedSetName,
-      startIndex,
-      endIndex
+      options?.order ?? SortedSetOrder.Ascending,
+      options?.startIndex ?? 0,
+      options?.endIndex
     );
   }
 

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -50,6 +50,7 @@ import {
   FrontTruncatableCallOptions,
   ScalarCallOptions,
   SortedSetFetchByIndexCallOptions,
+  SortedSetFetchByScoreCallOptions,
   SortedSetOrder,
 } from './utils/cache-call-options';
 
@@ -68,6 +69,7 @@ type DictionaryIncrementOptions = CollectionCallOptions;
 type IncrementOptions = ScalarCallOptions;
 type SortedSetPutValueOptions = CollectionCallOptions;
 type SortedSetFetchByIndexOptions = SortedSetFetchByIndexCallOptions;
+type SortedSetFetchByScoreOptions = SortedSetFetchByScoreCallOptions;
 type SortedSetIncrementOptions = CollectionCallOptions;
 
 /**
@@ -874,14 +876,16 @@ export class SimpleCacheClient {
   // sorted set put values
 
   /**
-   * Fetch the elements in the given sorted set.
+   * Fetch the elements in the given sorted set by index (rank).
    *
    * @param {string} cacheName - The cache containing the sorted set.
    * @param {string} sortedSetName - The sorted set to fetch from.
    * @param {SortedSetFetchByIndexOptions} options
    * @param {number} [options.startIndex] - The index of the first element to
-   * fetch. Defaults to 0.
+   * fetch. Defaults to 0. This index is inclusive, ie the element at this index
+   * will be fetched.
    * @param {number} [options.endIndex] - The index of the last element to fetch.
+   * This index is exclusive, ie the element at this index will not be fetched.
    * Defaults to null, which fetches up until and including the last element.
    * @param {SortedSetOrder} [options.order] - The order to fetch the elements in.
    * Defaults to ascending.
@@ -905,7 +909,38 @@ export class SimpleCacheClient {
     );
   }
 
-  // sorted set fetch by score
+  /**
+   * Fetch the elements in the given sorted set by score.
+   *
+   * @param {string} cacheName - The cache containing the sorted set.
+   * @param {string} sortedSetName - The sorted set to fetch from.
+   * @param {SortedSetFetchByScoreOptions} options
+   * @param {number} [options.minScore] - The minimum score (inclusive) of the
+   * elements to fetch. Defaults to negative infinity.
+   * @param {number} [options.maxScore] - The maximum score (inclusive) of the
+   * elements to fetch. Defaults to positive infinity.
+   * @param {SortedSetOrder} [options.order] - The order to fetch the elements in.
+   * Defaults to ascending.
+   * @returns {Promise<CacheSortedSetFetch.Response>} -
+   * {@link CacheSortedSetFetch.Hit} containing the requested elements when found.
+   * {@link CacheSortedSetFetch.Miss} when the sorted set does not exist.
+   * {@link CacheSortedSetFetch.Error} on failure.
+   */
+  public async sortedSetFetchByScore(
+    cacheName: string,
+    sortedSetName: string,
+    options?: SortedSetFetchByScoreOptions
+  ): Promise<CacheSortedSetFetch.Response> {
+    const client = this.getNextDataClient();
+    return await client.sortedSetFetchByScore(
+      cacheName,
+      sortedSetName,
+      options?.order ?? SortedSetOrder.Ascending,
+      options?.minScore,
+      options?.maxScore
+    );
+  }
+
   // sorted set get score
   // sorted set get scores
 

--- a/src/utils/cache-call-options.ts
+++ b/src/utils/cache-call-options.ts
@@ -34,7 +34,41 @@ export enum SortedSetOrder {
 }
 
 export interface SortedSetFetchByIndexCallOptions {
+  /**
+   * The index of the first element to return, inclusive.
+   * If negative, the index is relative to the end of the list.
+   * If the index is not specified, the first element is used.
+   */
   startIndex?: number;
+  /**
+   * The index of the last element to return, exclusive.
+   * If negative, the index is relative to the end of the list.
+   * If the index is not specified, the range extends to the end of the list.
+   */
   endIndex?: number;
+  /**
+   * The order in which to return the elements.
+   * If the order is not specified, the elements are returned in ascending order.
+   * If descending order is used, the start and end indexes are interpreted as if
+   * the list were reversed.
+   */
+  order?: SortedSetOrder;
+}
+
+export interface SortedSetFetchByScoreCallOptions {
+  /**
+   * The minimum score of the elements to return, inclusive.
+   * If the minimum score is not specified, the range extends to the lowest score.
+   */
+  minScore?: number;
+  /**
+   * The maximum score of the elements to return, inclusive.
+   * If the maximum score is not specified, the range extends to the highest score.
+   */
+  maxScore?: number;
+  /**
+   * The order in which to return the elements.
+   * If the order is not specified, the elements are returned in ascending order.
+   */
   order?: SortedSetOrder;
 }

--- a/src/utils/cache-call-options.ts
+++ b/src/utils/cache-call-options.ts
@@ -27,3 +27,14 @@ export interface BackTruncatableCallOptions extends CollectionCallOptions {
    */
   truncateBackToSize?: number;
 }
+
+export enum SortedSetOrder {
+  Ascending = 'ASC',
+  Descending = 'DESC',
+}
+
+export interface SortedSetFetchByIndexCallOptions {
+  startIndex?: number;
+  endIndex?: number;
+  order?: SortedSetOrder;
+}


### PR DESCRIPTION
Implements `sortedSetFetchByScore`. A future PR will implement the other features of this API, including min/max inclusive vs exclusive flags, limit, and count; as well as testing.