### PR TITLE
feat: rename SimpleCacheClient to CacheClient

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -87,13 +87,13 @@ if (getResponse instanceof CacheGet.Hit) {
 
 ### Error Handling
 
-Errors that occur in calls to `SimpleCacheClient` methods are surfaced to developers as part of the return values of
+Errors that occur in calls to `CacheClient` methods are surfaced to developers as part of the return values of
 the calls, as opposed to by throwing exceptions. This makes them more visible, and allows your IDE to be more
 helpful in ensuring that you've handled the ones you care about. (For more on our philosophy about this, see our
 blog post on why [Exceptions are bugs](https://www.gomomento.com/blog/exceptions-are-bugs). And send us any
 feedback you have!)
 
-The preferred way of interpreting the return values from `SimpleCacheClient` methods is
+The preferred way of interpreting the return values from `CacheClient` methods is
 using `instanceof` to match and handle the specific response type. Here's a quick example:
 
 ```typescript
@@ -122,8 +122,8 @@ if (getResponse instanceof CacheGet.Error) {
 }
 ```
 
-Note that, outside of `SimpleCacheClient` responses, exceptions can occur and should be handled as usual. For example,
-trying to instantiate a `SimpleCacheClient` with an invalid authentication token will result in an
+Note that, outside of `CacheClient` responses, exceptions can occur and should be handled as usual. For example,
+trying to instantiate a `CacheClient` with an invalid authentication token will result in an
 `IllegalArgumentException` being thrown.
 
 ### Tuning

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -16,7 +16,7 @@ interface CredentialProviderProps {
 }
 
 /**
- * Provides information that the SimpleCacheClient needs in order to establish a connection to and authenticate with
+ * Provides information that the CacheClient needs in order to establish a connection to and authenticate with
  * the Momento service.
  * @export
  * @interface CredentialProvider

--- a/src/cache-client-props.ts
+++ b/src/cache-client-props.ts
@@ -1,7 +1,7 @@
 import {CredentialProvider} from './auth/credential-provider';
 import {Configuration} from './config/configuration';
 
-export interface SimpleCacheClientProps {
+export interface CacheClientProps {
   /**
    * Configuration settings for the cache client
    */
@@ -15,3 +15,8 @@ export interface SimpleCacheClientProps {
    */
   defaultTtlSeconds: number;
 }
+
+/**
+ * @deprecated use {CacheClientProps} instead
+ */
+export type SimpleCacheClientProps = CacheClientProps;

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -85,7 +85,7 @@ export interface Configuration {
   withClientTimeoutMillis(clientTimeoutMillis: number): Configuration;
 }
 
-export class SimpleCacheConfiguration implements Configuration {
+export class CacheConfiguration implements Configuration {
   private readonly loggerFactory: MomentoLoggerFactory;
   private readonly retryStrategy: RetryStrategy;
   private readonly transportStrategy: TransportStrategy;
@@ -107,7 +107,7 @@ export class SimpleCacheConfiguration implements Configuration {
   }
 
   withRetryStrategy(retryStrategy: RetryStrategy): Configuration {
-    return new SimpleCacheConfiguration({
+    return new CacheConfiguration({
       loggerFactory: this.loggerFactory,
       retryStrategy: retryStrategy,
       transportStrategy: this.transportStrategy,
@@ -120,7 +120,7 @@ export class SimpleCacheConfiguration implements Configuration {
   }
 
   withTransportStrategy(transportStrategy: TransportStrategy): Configuration {
-    return new SimpleCacheConfiguration({
+    return new CacheConfiguration({
       loggerFactory: this.loggerFactory,
       retryStrategy: this.retryStrategy,
       transportStrategy: transportStrategy,
@@ -133,7 +133,7 @@ export class SimpleCacheConfiguration implements Configuration {
   }
 
   withMiddlewares(middlewares: Middleware[]): Configuration {
-    return new SimpleCacheConfiguration({
+    return new CacheConfiguration({
       loggerFactory: this.loggerFactory,
       retryStrategy: this.retryStrategy,
       transportStrategy: this.transportStrategy,
@@ -142,7 +142,7 @@ export class SimpleCacheConfiguration implements Configuration {
   }
 
   addMiddleware(middleware: Middleware): Configuration {
-    return new SimpleCacheConfiguration({
+    return new CacheConfiguration({
       loggerFactory: this.loggerFactory,
       retryStrategy: this.retryStrategy,
       transportStrategy: this.transportStrategy,
@@ -151,7 +151,7 @@ export class SimpleCacheConfiguration implements Configuration {
   }
 
   withClientTimeoutMillis(clientTimeout: number): Configuration {
-    return new SimpleCacheConfiguration({
+    return new CacheConfiguration({
       loggerFactory: this.loggerFactory,
       retryStrategy: this.retryStrategy,
       transportStrategy:

--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -1,4 +1,4 @@
-import {SimpleCacheConfiguration} from './configuration';
+import {CacheConfiguration} from './configuration';
 import {
   TransportStrategy,
   StaticGrpcConfiguration,
@@ -33,16 +33,16 @@ function defaultRetryStrategy(
  * @export
  * @class Laptop
  */
-export class Laptop extends SimpleCacheConfiguration {
+export class Laptop extends CacheConfiguration {
   /**
    * Provides the latest recommended configuration for a laptop development environment.  NOTE: this configuration may
    * change in future releases to take advantage of improvements we identify for default configurations.
    * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
-   * @returns {SimpleCacheConfiguration}
+   * @returns {CacheConfiguration}
    */
   static latest(
     loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
-  ): SimpleCacheConfiguration {
+  ): CacheConfiguration {
     return Laptop.v1(loggerFactory);
   }
 
@@ -50,11 +50,11 @@ export class Laptop extends SimpleCacheConfiguration {
    * Provides v1 recommended configuration for a laptop development environment.  This configuration is guaranteed not
    * to change in future releases of the Momento node.js SDK.
    * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
-   * @returns {SimpleCacheConfiguration}
+   * @returns {CacheConfiguration}
    */
   static v1(
     loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
-  ): SimpleCacheConfiguration {
+  ): CacheConfiguration {
     const deadlineMillis = 5000;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
@@ -73,16 +73,16 @@ export class Laptop extends SimpleCacheConfiguration {
   }
 }
 
-class InRegionDefault extends SimpleCacheConfiguration {
+class InRegionDefault extends CacheConfiguration {
   /**
    * Provides the latest recommended configuration for a typical in-region environment.  NOTE: this configuration may
    * change in future releases to take advantage of improvements we identify for default configurations.
    * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
-   * @returns {SimpleCacheConfiguration}
+   * @returns {CacheConfiguration}
    */
   static latest(
     loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
-  ): SimpleCacheConfiguration {
+  ): CacheConfiguration {
     return InRegionDefault.v1(loggerFactory);
   }
 
@@ -90,11 +90,11 @@ class InRegionDefault extends SimpleCacheConfiguration {
    * Provides v1 recommended configuration for a typical in-region environment.  This configuration is guaranteed not
    * to change in future releases of the Momento node.js SDK.
    * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
-   * @returns {SimpleCacheConfiguration}
+   * @returns {CacheConfiguration}
    */
   static v1(
     loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
-  ): SimpleCacheConfiguration {
+  ): CacheConfiguration {
     const deadlineMillis = 1100;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
@@ -113,17 +113,17 @@ class InRegionDefault extends SimpleCacheConfiguration {
   }
 }
 
-class InRegionLowLatency extends SimpleCacheConfiguration {
+class InRegionLowLatency extends CacheConfiguration {
   /**
    * Provides the latest recommended configuration for an in-region environment with aggressive low-latency requirements.
    * NOTE: this configuration may change in future releases to take advantage of improvements we identify for default
    * configurations.
    * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
-   * @returns {SimpleCacheConfiguration}
+   * @returns {CacheConfiguration}
    */
   static latest(
     loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
-  ): SimpleCacheConfiguration {
+  ): CacheConfiguration {
     return InRegionLowLatency.v1(loggerFactory);
   }
 
@@ -131,11 +131,11 @@ class InRegionLowLatency extends SimpleCacheConfiguration {
    * Provides v1 recommended configuration for an in-region environment with aggressive low-latency requirements.
    * This configuration is guaranteed not to change in future releases of the Momento node.js SDK.
    * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
-   * @returns {SimpleCacheConfiguration}
+   * @returns {CacheConfiguration}
    */
   static v1(
     loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
-  ): SimpleCacheConfiguration {
+  ): CacheConfiguration {
     const deadlineMillis = 500;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {SimpleCacheClient} from './simple-cache-client';
+import {CacheClient, SimpleCacheClient} from './cache-client';
 import * as Configurations from './config/configurations';
 import * as CacheGet from './messages/responses/cache-get';
 import * as CacheListConcatenateBack from './messages/responses/cache-list-concatenate-back';
@@ -94,6 +94,7 @@ export {
   CredentialProvider,
   StringMomentoTokenProvider,
   EnvMomentoTokenProvider,
+  CacheClient,
   SimpleCacheClient,
   CacheGet,
   CacheListConcatenateBack,

--- a/src/internal/data-client.ts
+++ b/src/internal/data-client.ts
@@ -66,13 +66,13 @@ import {
   validateSortedSetRanks,
   validateSortedSetScores,
 } from './utils/validators';
-import {SimpleCacheClientProps} from '../simple-cache-client-props';
+import {CacheClientProps} from '../cache-client-props';
 import {Middleware} from '../config/middleware/middleware';
 import {middlewaresInterceptor} from './grpc/middlewares-interceptor';
 import {truncateString} from './utils/display';
 import {SdkError} from '../errors/errors';
 
-export class CacheClient {
+export class DataClient {
   private readonly clientWrapper: GrpcClientWrapper<grpcCache.ScsClient>;
   private readonly textEncoder: TextEncoder;
   private readonly configuration: Configuration;
@@ -84,9 +84,9 @@ export class CacheClient {
   private readonly interceptors: Interceptor[];
 
   /**
-   * @param {SimpleCacheClientProps} props
+   * @param {CacheClientProps} props
    */
-  constructor(props: SimpleCacheClientProps) {
+  constructor(props: CacheClientProps) {
     this.configuration = props.configuration;
     this.credentialProvider = props.credentialProvider;
     this.logger = this.configuration.getLoggerFactory().getLogger(this);
@@ -95,7 +95,7 @@ export class CacheClient {
       .getGrpcConfig();
 
     this.requestTimeoutMs =
-      grpcConfig.getDeadlineMillis() || CacheClient.DEFAULT_REQUEST_TIMEOUT_MS;
+      grpcConfig.getDeadlineMillis() || DataClient.DEFAULT_REQUEST_TIMEOUT_MS;
     this.validateRequestTimeout(this.requestTimeoutMs);
     this.logger.debug(
       `Creating cache client using endpoint: '${this.credentialProvider.getCacheEndpoint()}'`

--- a/test/integration/get-set-delete.test.ts
+++ b/test/integration/get-set-delete.test.ts
@@ -6,13 +6,13 @@ import {
   CacheSet,
   CacheSetIfNotExists,
   MomentoErrorCode,
-  SimpleCacheClient,
+  CacheClient,
 } from '../../src';
 import {TextEncoder} from 'util';
 import {
   SetupIntegrationTest,
   ValidateCacheProps,
-  CacheClientProps,
+  IntegrationTestCacheClientProps,
   ItBehavesLikeItValidatesCacheName,
   WithCache,
 } from './integration-setup';
@@ -117,16 +117,17 @@ describe('get/set/delete', () => {
   it('should timeout on a request that exceeds specified timeout', async () => {
     const cacheName = v4();
     const defaultTimeoutClient = Momento;
-    const shortTimeoutTransportStrategy = CacheClientProps.configuration
-      .getTransportStrategy()
-      .withClientTimeoutMillis(1);
+    const shortTimeoutTransportStrategy =
+      IntegrationTestCacheClientProps.configuration
+        .getTransportStrategy()
+        .withClientTimeoutMillis(1);
     const shortTimeoutConfiguration =
-      CacheClientProps.configuration.withTransportStrategy(
+      IntegrationTestCacheClientProps.configuration.withTransportStrategy(
         shortTimeoutTransportStrategy
       );
-    const shortTimeoutClient = new SimpleCacheClient({
+    const shortTimeoutClient = new CacheClient({
       configuration: shortTimeoutConfiguration,
-      credentialProvider: CacheClientProps.credentialProvider,
+      credentialProvider: IntegrationTestCacheClientProps.credentialProvider,
       defaultTtlSeconds: 1111,
     });
     await WithCache(defaultTimeoutClient, cacheName, async () => {
@@ -413,16 +414,17 @@ describe('#setIfNotExists', () => {
   it('should timeout on a request that exceeds specified timeout', async () => {
     const cacheName = v4();
     const defaultTimeoutClient = Momento;
-    const shortTimeoutTransportStrategy = CacheClientProps.configuration
-      .getTransportStrategy()
-      .withClientTimeoutMillis(1);
+    const shortTimeoutTransportStrategy =
+      IntegrationTestCacheClientProps.configuration
+        .getTransportStrategy()
+        .withClientTimeoutMillis(1);
     const shortTimeoutConfiguration =
-      CacheClientProps.configuration.withTransportStrategy(
+      IntegrationTestCacheClientProps.configuration.withTransportStrategy(
         shortTimeoutTransportStrategy
       );
-    const shortTimeoutClient = new SimpleCacheClient({
+    const shortTimeoutClient = new CacheClient({
       configuration: shortTimeoutConfiguration,
-      credentialProvider: CacheClientProps.credentialProvider,
+      credentialProvider: IntegrationTestCacheClientProps.credentialProvider,
       defaultTtlSeconds: 1111,
     });
     await WithCache(defaultTimeoutClient, cacheName, async () => {

--- a/test/integration/integration-setup.ts
+++ b/test/integration/integration-setup.ts
@@ -1,12 +1,12 @@
 import {v4} from 'uuid';
-import {SimpleCacheClientProps} from '../../src/simple-cache-client-props';
+import {CacheClientProps} from '../../src/cache-client-props';
 import {
   CreateCache,
   Configurations,
   DeleteCache,
   CollectionTtl,
   MomentoErrorCode,
-  SimpleCacheClient,
+  CacheClient,
   CredentialProvider,
 } from '../../src';
 import {
@@ -19,10 +19,7 @@ function testCacheName(): string {
   return name + v4();
 }
 
-const deleteCacheIfExists = async (
-  momento: SimpleCacheClient,
-  cacheName: string
-) => {
+const deleteCacheIfExists = async (momento: CacheClient, cacheName: string) => {
   const deleteResponse = await momento.deleteCache(cacheName);
   if (deleteResponse instanceof DeleteCache.Error) {
     if (deleteResponse.errorCode() !== MomentoErrorCode.NOT_FOUND_ERROR) {
@@ -32,7 +29,7 @@ const deleteCacheIfExists = async (
 };
 
 export async function WithCache(
-  client: SimpleCacheClient,
+  client: CacheClient,
   cacheName: string,
   block: () => Promise<void>
 ) {
@@ -45,7 +42,7 @@ export async function WithCache(
   }
 }
 
-export const CacheClientProps: SimpleCacheClientProps = {
+export const IntegrationTestCacheClientProps: CacheClientProps = {
   configuration: Configurations.Laptop.latest(),
   credentialProvider: CredentialProvider.fromEnvironmentVariable({
     environmentVariableName: 'TEST_AUTH_TOKEN',
@@ -54,11 +51,11 @@ export const CacheClientProps: SimpleCacheClientProps = {
 };
 
 function momentoClientForTesting() {
-  return new SimpleCacheClient(CacheClientProps);
+  return new CacheClient(IntegrationTestCacheClientProps);
 }
 
 export function SetupIntegrationTest(): {
-  Momento: SimpleCacheClient;
+  Momento: CacheClient;
   IntegrationTestCacheName: string;
 } {
   const cacheName = testCacheName();

--- a/test/unit/cache-client.test.ts
+++ b/test/unit/cache-client.test.ts
@@ -1,20 +1,31 @@
 import {
   Configurations,
   InvalidArgumentError,
+  CacheClient,
   SimpleCacheClient,
 } from '../../src';
 import * as CreateCache from '../../src/messages/responses/create-cache';
 import {StringMomentoTokenProvider} from '../../src/auth/credential-provider';
+import {SimpleCacheClientProps} from '../../src/cache-client-props';
 const credentialProvider = new StringMomentoTokenProvider({
   authToken:
     'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImNwIjoiY29udHJvbCBwbGFuZSBlbmRwb2ludCIsImMiOiJkYXRhIHBsYW5lIGVuZHBvaW50In0.zsTsEXFawetTCZI',
 });
 const configuration = Configurations.Laptop.latest();
 
-describe('SimpleCacheClient.ts', () => {
+describe('CacheClient', () => {
+  it('can construct a CacheClient with the legacy class name SimpleCacheClient', () => {
+    const props: SimpleCacheClientProps = {
+      configuration: configuration,
+      credentialProvider: credentialProvider,
+      defaultTtlSeconds: 100,
+    };
+    new SimpleCacheClient(props);
+  });
+
   it('cannot create/get cache with invalid name', async () => {
     const invalidCacheNames = ['', '    '];
-    const momento = new SimpleCacheClient({
+    const momento = new CacheClient({
       configuration: configuration,
       credentialProvider: credentialProvider,
       defaultTtlSeconds: 100,
@@ -34,7 +45,7 @@ describe('SimpleCacheClient.ts', () => {
       const invalidTimeoutConfig = configuration.withTransportStrategy(
         configuration.getTransportStrategy().withClientTimeoutMillis(-1)
       );
-      new SimpleCacheClient({
+      new CacheClient({
         configuration: invalidTimeoutConfig,
         credentialProvider: credentialProvider,
         defaultTtlSeconds: 100,

--- a/test/unit/config/configuration.test.ts
+++ b/test/unit/config/configuration.test.ts
@@ -1,4 +1,4 @@
-import {SimpleCacheConfiguration} from '../../../src/config/configuration';
+import {CacheConfiguration} from '../../../src/config/configuration';
 import {
   StaticGrpcConfiguration,
   StaticTransportStrategy,
@@ -23,7 +23,7 @@ describe('configuration.ts', () => {
     maxIdleMillis: testMaxIdleMillis,
   });
   const testMiddlewares: Middleware[] = [];
-  const testConfiguration = new SimpleCacheConfiguration({
+  const testConfiguration = new CacheConfiguration({
     loggerFactory: testLoggerFactory,
     retryStrategy: testRetryStrategy,
     transportStrategy: testTransportStrategy,


### PR DESCRIPTION
This commit renames the primary client object from SimpleCacheClient
to CacheClient, after we received feedback from users that the
name was misleading and seemed to imply that there were multiple
clients to choose from.

The legacy name is retained as a type alias with a deprecation
warning so that this change is backward-compatible.
