### PR TITLE
chore: Add request coalescer example

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -10,6 +10,7 @@
     "advanced": "tsc && node dist/advanced.js",
     "load-gen": "tsc && node dist/load-gen.js",
     "dictionary": "tsc && node dist/dictionary.js",
+    "request-coalescing": "tsc && node dist/request-coalescing.js",
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "format": "eslint . --ext .ts --fix"

--- a/examples/utils/cache.ts
+++ b/examples/utils/cache.ts
@@ -1,0 +1,38 @@
+import {
+  CacheClient,
+  Configurations,
+  CreateCache,
+  EnvMomentoTokenProvider,
+  MomentoLogger,
+  MomentoLoggerFactory,
+} from '@gomomento/sdk';
+
+export function getCacheClient(
+  loggerFactory: MomentoLoggerFactory,
+  requestTimeoutMs: number,
+  cacheItemTtlSeconds: number
+) {
+  return new CacheClient({
+    configuration:
+      Configurations.Laptop.v1(loggerFactory).withClientTimeoutMillis(
+        requestTimeoutMs
+      ),
+    credentialProvider: new EnvMomentoTokenProvider({
+      environmentVariableName: 'MOMENTO_AUTH_TOKEN',
+    }),
+    defaultTtlSeconds: cacheItemTtlSeconds,
+  });
+}
+
+export async function createCache(
+  momentCacheClient: CacheClient,
+  cacheName: string,
+  logger: MomentoLogger
+) {
+  const createResponse = await momentCacheClient.createCache(cacheName);
+  if (createResponse instanceof CreateCache.AlreadyExists) {
+    logger.info(`cache '${cacheName}' already exists`);
+  } else if (createResponse instanceof CreateCache.Error) {
+    throw createResponse.innerException();
+  }
+}

--- a/examples/utils/load-gen-statistics-calculator.ts
+++ b/examples/utils/load-gen-statistics-calculator.ts
@@ -1,0 +1,104 @@
+import {BasicLoadGenContext, RequestCoalescerContext} from './load-gen';
+import * as hdr from 'hdr-histogram-js';
+import {MomentoLogger} from '@gomomento/sdk';
+import {load} from '@grpc/grpc-js';
+
+export function tps(
+  context: BasicLoadGenContext,
+  requestCount: number
+): number {
+  return Math.round(
+    (requestCount * 1000) / getElapsedMillis(context.startTime)
+  );
+}
+
+export function getElapsedMillis(startTime: [number, number]): number {
+  const endTime = process.hrtime(startTime);
+  return (endTime[0] * 1e9 + endTime[1]) / 1e6;
+}
+
+export function percentRequests(
+  context: BasicLoadGenContext,
+  count: number
+): string {
+  return (
+    Math.round((count / context.globalRequestCount) * 100 * 10) / 10
+  ).toString();
+}
+
+export function outputHistogramSummary(histogram: hdr.Histogram): string {
+  return `
+  count: ${histogram.totalCount}
+    min: ${histogram.minNonZeroValue}
+    p50: ${histogram.getValueAtPercentile(50)}
+    p90: ${histogram.getValueAtPercentile(90)}
+    p99: ${histogram.getValueAtPercentile(99)}
+  p99.9: ${histogram.getValueAtPercentile(99.9)}
+    max: ${histogram.maxValue}
+`;
+}
+
+export function logStats(
+  loadGenContext: BasicLoadGenContext,
+  logger: MomentoLogger,
+  maxRequestsPerSecond: number
+): void {
+  logger.info(`
+cumulative stats:
+total requests: ${loadGenContext.globalRequestCount} (${tps(
+    loadGenContext,
+    loadGenContext.globalRequestCount
+  )} tps, limited to ${maxRequestsPerSecond} tps)
+       success: ${loadGenContext.globalSuccessCount} (${percentRequests(
+    loadGenContext,
+    loadGenContext.globalSuccessCount
+  )}%) (${tps(loadGenContext, loadGenContext.globalSuccessCount)} tps)
+   unavailable: ${loadGenContext.globalUnavailableCount} (${percentRequests(
+    loadGenContext,
+    loadGenContext.globalUnavailableCount
+  )}%)
+deadline exceeded: ${
+    loadGenContext.globalDeadlineExceededCount
+  } (${percentRequests(
+    loadGenContext,
+    loadGenContext.globalDeadlineExceededCount
+  )}%)
+resource exhausted: ${
+    loadGenContext.globalResourceExhaustedCount
+  } (${percentRequests(
+    loadGenContext,
+    loadGenContext.globalResourceExhaustedCount
+  )}%)
+    rst stream: ${loadGenContext.globalRstStreamCount} (${percentRequests(
+    loadGenContext,
+    loadGenContext.globalRstStreamCount
+  )}%)
+
+cumulative set latencies:
+${outputHistogramSummary(loadGenContext.setLatencies)}
+
+cumulative get latencies:
+${outputHistogramSummary(loadGenContext.getLatencies)}
+`);
+}
+
+export function logCoalescingStats(
+  context: RequestCoalescerContext,
+  loadGenContext: BasicLoadGenContext,
+  logger: MomentoLogger
+): void {
+  logger.info(`
+For request coalescer:
+Number of set requests coalesced:
+${context.numberOfSetRequestsCoalesced} (${percentRequests(
+    loadGenContext,
+    context.numberOfSetRequestsCoalesced
+  )}%)
+
+Number of get requests coalesced:
+${context.numberOfGetRequestsCoalesced} (${percentRequests(
+    loadGenContext,
+    context.numberOfGetRequestsCoalesced
+  )}%)
+`);
+}

--- a/examples/utils/load-gen.ts
+++ b/examples/utils/load-gen.ts
@@ -1,0 +1,150 @@
+import {
+  CacheGet,
+  CacheSet,
+  InternalServerError,
+  LimitExceededError,
+  MomentoLogger,
+  MomentoLoggerFactory,
+  TimeoutError,
+} from '@gomomento/sdk';
+import * as hdr from 'hdr-histogram-js';
+
+export interface BasicLoadGenOptions {
+  loggerFactory: MomentoLoggerFactory;
+  requestTimeoutMs: number;
+  cacheItemPayloadBytes: number;
+  numberOfConcurrentRequests: number;
+  showStatsIntervalSeconds: number;
+  maxRequestsPerSecond: number;
+  totalSecondsToRun: number;
+}
+
+export enum AsyncSetGetResult {
+  SUCCESS = 'SUCCESS',
+  UNAVAILABLE = 'UNAVAILABLE',
+  DEADLINE_EXCEEDED = 'DEADLINE_EXCEEDED',
+  RESOURCE_EXHAUSTED = 'RESOURCE_EXHAUSTED',
+  RST_STREAM = 'RST_STREAM',
+}
+
+export interface BasicLoadGenContext {
+  startTime: [number, number];
+  getLatencies: hdr.Histogram;
+  setLatencies: hdr.Histogram;
+  // TODO: these could be generalized into a map structure that
+  //  would make it possible to deal with a broader range of
+  //  failure types more succinctly.
+  globalRequestCount: number;
+  globalSuccessCount: number;
+  globalUnavailableCount: number;
+  globalDeadlineExceededCount: number;
+  globalResourceExhaustedCount: number;
+  globalRstStreamCount: number;
+}
+
+export interface RequestCoalescerContext {
+  numberOfSetRequestsCoalesced: number;
+  numberOfGetRequestsCoalesced: number;
+}
+
+export function updateContextCountsForRequest(
+  context: BasicLoadGenContext,
+  result: AsyncSetGetResult
+): void {
+  context.globalRequestCount++;
+  // TODO: this could be simplified and made more generic, worth doing if we ever want to
+  //  expand this to additional types of behavior
+  switch (result) {
+    case AsyncSetGetResult.SUCCESS:
+      context.globalSuccessCount++;
+      break;
+    case AsyncSetGetResult.UNAVAILABLE:
+      context.globalUnavailableCount++;
+      break;
+    case AsyncSetGetResult.DEADLINE_EXCEEDED:
+      context.globalDeadlineExceededCount++;
+      break;
+    case AsyncSetGetResult.RESOURCE_EXHAUSTED:
+      context.globalResourceExhaustedCount++;
+      break;
+    case AsyncSetGetResult.RST_STREAM:
+      context.globalRstStreamCount++;
+      break;
+  }
+}
+
+export async function executeRequestAndUpdateContextCounts<T>(
+  logger: MomentoLogger,
+  context: BasicLoadGenContext,
+  block: () => Promise<T>
+): Promise<T | undefined> {
+  const [result, response] = await executeRequest(logger, block);
+  updateContextCountsForRequest(context, result);
+  return response;
+}
+
+export async function executeRequest<T>(
+  logger: MomentoLogger,
+  block: () => Promise<T>
+): Promise<[AsyncSetGetResult, T | undefined]> {
+  try {
+    const result = await block();
+    if (result instanceof CacheSet.Error || result instanceof CacheGet.Error) {
+      throw result.innerException();
+    }
+    return [AsyncSetGetResult.SUCCESS, result];
+  } catch (e) {
+    if (e instanceof InternalServerError) {
+      if (e.message.includes('UNAVAILABLE')) {
+        return [AsyncSetGetResult.UNAVAILABLE, undefined];
+      } else if (e.message.includes('RST_STREAM')) {
+        logger.error(
+          `Caught RST_STREAM error; swallowing: ${e.name}, ${e.message}`
+        );
+        return [AsyncSetGetResult.RST_STREAM, undefined];
+      } else {
+        throw e;
+      }
+    } else if (e instanceof LimitExceededError) {
+      if (e.message.includes('RESOURCE_EXHAUSTED')) {
+        logger.error(
+          `Caught RESOURCE_EXHAUSTED error; swallowing: ${e.name}, ${e.message}`
+        );
+        return [AsyncSetGetResult.RESOURCE_EXHAUSTED, undefined];
+      } else {
+        throw e;
+      }
+    } else if (e instanceof TimeoutError) {
+      if (e.message.includes('DEADLINE_EXCEEDED')) {
+        return [AsyncSetGetResult.DEADLINE_EXCEEDED, undefined];
+      } else {
+        throw e;
+      }
+    } else {
+      throw e;
+    }
+  }
+}
+
+export function initiateLoadGenContext(): BasicLoadGenContext {
+  const loadGenContext: BasicLoadGenContext = {
+    startTime: process.hrtime(),
+    getLatencies: hdr.build(),
+    setLatencies: hdr.build(),
+    globalRequestCount: 0,
+    globalSuccessCount: 0,
+    globalUnavailableCount: 0,
+    globalDeadlineExceededCount: 0,
+    globalResourceExhaustedCount: 0,
+    globalRstStreamCount: 0,
+  };
+  return loadGenContext;
+}
+
+export function initiateRequestCoalescerContext(): RequestCoalescerContext {
+  const requestCoalescerContext: RequestCoalescerContext = {
+    numberOfSetRequestsCoalesced: 0,
+    numberOfGetRequestsCoalesced: 0,
+  };
+  return requestCoalescerContext;
+}

--- a/examples/utils/momento-client-with-coalescing.ts
+++ b/examples/utils/momento-client-with-coalescing.ts
@@ -1,0 +1,59 @@
+import {CacheClient, CacheGet, CacheSet} from '@gomomento/sdk';
+import {RequestCoalescerContext} from './load-gen';
+
+export interface GetAndSetOnlyClient {
+  get(cacheName: string, key: string): Promise<CacheGet.Response>;
+  set(
+    cacheName: string,
+    key: string,
+    value: string
+  ): Promise<CacheSet.Response>;
+}
+
+export class MomentoClientWrapperWithCoalescing {
+  private readonly momentoClient: CacheClient;
+  private readonly context: RequestCoalescerContext;
+  private readonly getRequestMap: Map<string, Promise<CacheGet.Response>>;
+  private readonly setRequestMap: Map<string, Promise<CacheSet.Response>>;
+
+  constructor(client: CacheClient, context: RequestCoalescerContext) {
+    this.momentoClient = client;
+    this.context = context;
+    this.getRequestMap = new Map<string, Promise<CacheGet.Response>>();
+    this.setRequestMap = new Map<string, Promise<CacheSet.Response>>();
+  }
+
+  get(cacheName: string, key: string): Promise<CacheGet.Response> {
+    if (this.getRequestMap.has(key)) {
+      this.context.numberOfGetRequestsCoalesced++;
+      const mapResponse = this.getRequestMap.get(key);
+      if (mapResponse !== undefined) {
+        return mapResponse;
+      }
+    }
+    const getPromise = this.momentoClient.get(cacheName, key);
+    this.getRequestMap.set(key, getPromise);
+    return getPromise.finally(() => {
+      this.getRequestMap.delete(key);
+    });
+  }
+
+  set(
+    cacheName: string,
+    key: string,
+    value: string
+  ): Promise<CacheSet.Response> {
+    if (this.setRequestMap.has(key)) {
+      this.context.numberOfSetRequestsCoalesced++;
+      const mapResponse = this.setRequestMap.get(key);
+      if (mapResponse !== undefined) {
+        return mapResponse;
+      }
+    }
+    const setPromise = this.momentoClient.set(cacheName, key, value);
+    this.setRequestMap.set(key, setPromise);
+    return setPromise.finally(() => {
+      this.setRequestMap.delete(key);
+    });
+  }
+}


### PR DESCRIPTION
## PR Desciption:
### Revision3
- Addressed comment feedback 

### Revision2
1. Add request coalescing class that implements gets and sets from the map (with keys as cacheKeys and values as cache response promises) (Thanks Chris for helping me out!)
2. Add metric to record number of get/set requests coalesced

### Revision1 
1. Add request coalescing example
    - Runs concurrent requests(~200) using the basic load-generator
    - Runs conscurrent requests(~200) using the request-coleascer-load-generator
    - Prints the histogram and some stats for both the cases as they run for 60 sec. 
1. Refactor overlapping pieces of code to utils

## Issue:
https://github.com/momentohq/dev-eco-issue-tracker/issues/204

## Run the example
1. `npm install`
4. `MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> npm run request-coalescing`

## Stats:
For 200 concurrent requests, ran for 60 sec with 100 requests (max) allowed per sec
- Basic load-gen stats:
<img width="534" alt="BasicLoadGen" src="https://user-images.githubusercontent.com/127137312/225695807-670ad051-d224-4d86-ae86-6e7ee5a67dee.png">

- Request Coalescer load-gen stats:
<img width="629" alt="RequestCoalescer" src="https://user-images.githubusercontent.com/127137312/225695847-c80c71a0-668d-4717-9527-f620b111db17.png">

More stats when configuration/parameters are tweaked can be found in this Notion wiki - https://momentohq.notion.site/Request-Coalescing-Stats-7c4efeeab9d448538647712e3d7e1dff

## Stats Inference:
Observe how the latencies have significantly reduced when using request-coalescer-load-gen over basic load-gen. 
