### PR TITLE
fix: wrong name for dictionarySetField function in internal data client

### DIFF
--- a/src/cache-client.ts
+++ b/src/cache-client.ts
@@ -674,7 +674,7 @@ export class CacheClient {
     options?: DictionarySetFieldOptions
   ): Promise<CacheDictionarySetField.Response> {
     const client = this.getNextDataClient();
-    return await client.dictionarySendField(
+    return await client.dictionarySetField(
       cacheName,
       dictionaryName,
       field,

--- a/src/internal/data-client.ts
+++ b/src/internal/data-client.ts
@@ -1117,7 +1117,7 @@ export class DataClient {
     });
   }
 
-  public async dictionarySendField(
+  public async dictionarySetField(
     cacheName: string,
     dictionaryName: string,
     field: string | Uint8Array,


### PR DESCRIPTION
This just fixes a typo in the internal data client class.
