### PR TITLE
feat: add pubsub examples

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -31,9 +31,6 @@
       }
     },
     "../dist/src": {},
-    "../src": {
-      "extraneous": true
-    },
     "node_modules/@assemblyscript/loader": {
       "version": "0.19.23",
       "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.19.23.tgz",

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@gomomento/generated-types": "0.32.1",
-        "@gomomento/sdk": "1.4.0",
+        "@gomomento/sdk": "../dist/src",
         "@grpc/grpc-js": "1.7.3",
         "hdr-histogram-js": "3.0.0",
         "node-fetch": "2.6.7",
@@ -30,7 +30,8 @@
         "typescript": "4.4.3"
       }
     },
-    "../dist/src": {
+    "../dist/src": {},
+    "../src": {
       "extraneous": true
     },
     "node_modules/@assemblyscript/loader": {
@@ -72,38 +73,8 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.4.0.tgz",
-      "integrity": "sha512-ozcs0IDVycSgIPzIH+bfQ3UerTGkD8+tTPpHj7zcCAjti2nqA/pgm8Q3S8GsU5YI6B2EjMIYhwEdWk8Zi+BqIQ==",
-      "dependencies": {
-        "@gomomento/generated-types": "0.49.1",
-        "@grpc/grpc-js": "1.7.3",
-        "google-protobuf": "^3.21.2",
-        "jwt-decode": "3.1.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@gomomento/sdk/node_modules/@gomomento/generated-types": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.49.1.tgz",
-      "integrity": "sha512-j0jdhl4M6HJOWcDOKupGse74NEsFifqe2lirXsSKfc++1JIuFazkt6GO+ZtgRDlqP60S9B5ZX1kTpb0mBSd0tw==",
-      "dependencies": {
-        "@grpc/grpc-js": "1.7.3",
-        "@types/google-protobuf": "3.15.5",
-        "google-protobuf": "3.18.1"
-      }
-    },
-    "node_modules/@gomomento/sdk/node_modules/@gomomento/generated-types/node_modules/google-protobuf": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.18.1.tgz",
-      "integrity": "sha512-cDqSamZ8rGs+pOzhIsBte7wpezUKg/sggeptDWN5odhnRY/eDLa5VWLeNeQvcfiqjS3yUwgM+6OePCJMB7aWZA=="
-    },
-    "node_modules/@gomomento/sdk/node_modules/google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+      "resolved": "../dist/src",
+      "link": true
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.7.3",
@@ -2362,11 +2333,6 @@
         "json5": "lib/cli.js"
       }
     },
-    "node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3463,39 +3429,7 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.4.0.tgz",
-      "integrity": "sha512-ozcs0IDVycSgIPzIH+bfQ3UerTGkD8+tTPpHj7zcCAjti2nqA/pgm8Q3S8GsU5YI6B2EjMIYhwEdWk8Zi+BqIQ==",
-      "requires": {
-        "@gomomento/generated-types": "0.49.1",
-        "@grpc/grpc-js": "1.7.3",
-        "google-protobuf": "^3.21.2",
-        "jwt-decode": "3.1.2"
-      },
-      "dependencies": {
-        "@gomomento/generated-types": {
-          "version": "0.49.1",
-          "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.49.1.tgz",
-          "integrity": "sha512-j0jdhl4M6HJOWcDOKupGse74NEsFifqe2lirXsSKfc++1JIuFazkt6GO+ZtgRDlqP60S9B5ZX1kTpb0mBSd0tw==",
-          "requires": {
-            "@grpc/grpc-js": "1.7.3",
-            "@types/google-protobuf": "3.15.5",
-            "google-protobuf": "3.18.1"
-          },
-          "dependencies": {
-            "google-protobuf": {
-              "version": "3.18.1",
-              "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.18.1.tgz",
-              "integrity": "sha512-cDqSamZ8rGs+pOzhIsBte7wpezUKg/sggeptDWN5odhnRY/eDLa5VWLeNeQvcfiqjS3yUwgM+6OePCJMB7aWZA=="
-            }
-          }
-        },
-        "google-protobuf": {
-          "version": "3.21.2",
-          "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-          "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
-        }
-      }
+      "version": "file:../dist/src"
     },
     "@grpc/grpc-js": {
       "version": "1.7.3",
@@ -5113,11 +5047,6 @@
       "requires": {
         "minimist": "^1.2.0"
       }
-    },
-    "jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "levn": {
       "version": "0.4.1",

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,6 +10,8 @@
     "advanced": "tsc && node dist/advanced.js",
     "load-gen": "tsc && node dist/load-gen.js",
     "dictionary": "tsc && node dist/dictionary.js",
+    "topic-publish": "tsc && node dist/topic-publish.js",
+    "topic-subscribe": "tsc && node dist/topic-subscribe.js",
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "format": "eslint . --ext .ts --fix"
@@ -31,7 +33,7 @@
   },
   "dependencies": {
     "@gomomento/generated-types": "0.32.1",
-    "@gomomento/sdk": "1.4.0",
+    "@gomomento/sdk": "../dist/src",
     "@grpc/grpc-js": "1.7.3",
     "hdr-histogram-js": "3.0.0",
     "node-fetch": "2.6.7",

--- a/examples/topic-publish.ts
+++ b/examples/topic-publish.ts
@@ -1,0 +1,40 @@
+import {
+  TopicClient,
+  TopicPublish,
+  Configurations,
+  CredentialProvider,
+} from '@gomomento/sdk';
+
+async function main() {
+  const clargs = process.argv.slice(2);
+  if (clargs.length !== 3) {
+    console.error('Usage: topic-publish.ts <cacheName> <topicName> <value>');
+    return;
+  }
+  const [cacheName, topicName, value] = clargs;
+  const momento = new TopicClient({
+    configuration: Configurations.Laptop.v1(),
+    credentialProvider: CredentialProvider.fromEnvironmentVariable({
+      environmentVariableName: 'TEST_AUTH_TOKEN',
+    }),
+  });
+
+  console.log(
+    `Publishing cacheName=${cacheName}, topicName=${topicName}, value=${value}`
+  );
+  const publishResponse = await momento.publish(cacheName, topicName, value);
+  if (publishResponse instanceof TopicPublish.Success) {
+    console.log('Value published successfully!');
+  } else {
+    console.log(`Error publishing value: ${publishResponse.toString()}`);
+  }
+}
+
+main()
+  .then(() => {
+    console.log('success!!');
+  })
+  .catch((e: Error) => {
+    console.error(`An error occurred! ${e.message}`);
+    throw e;
+  });

--- a/examples/topic-subscribe.ts
+++ b/examples/topic-subscribe.ts
@@ -1,0 +1,44 @@
+import {
+  TopicClient,
+  TopicSubscribe,
+  Configurations,
+  CredentialProvider,
+} from '@gomomento/sdk';
+
+async function main() {
+  const clargs = process.argv.slice(2);
+  if (clargs.length !== 2) {
+    console.error('Usage: topic-subscribe.ts <cacheName> <topicName>');
+    return;
+  }
+  const [cacheName, topicName] = clargs;
+  const momento = new TopicClient({
+    configuration: Configurations.Laptop.v1(),
+    credentialProvider: CredentialProvider.fromEnvironmentVariable({
+      environmentVariableName: 'TEST_AUTH_TOKEN',
+    }),
+  });
+
+  console.log(`Subscribing to cacheName=${cacheName}, topicName=${topicName}`);
+  await momento.subscribe(cacheName, topicName, {
+    onItem: handleData,
+    onError: handleError,
+  });
+}
+
+function handleData(data: TopicSubscribe.Item) {
+  console.log('Data received from topic subscription; %s', data);
+}
+
+function handleError(error: TopicSubscribe.Error) {
+  console.log(`Error received from topic subscription; ${error.toString()}`);
+}
+
+main()
+  .then(() => {
+    console.log('success!!');
+  })
+  .catch((e: Error) => {
+    console.error(`An error occurred! ${e.message}`);
+    throw e;
+  });

--- a/examples/topic-subscribe.ts
+++ b/examples/topic-subscribe.ts
@@ -30,8 +30,11 @@ function handleData(data: TopicSubscribe.Item) {
   console.log('Data received from topic subscription; %s', data);
 }
 
-function handleError(error: TopicSubscribe.Error) {
+function handleError(error: TopicSubscribe.Error, unsubscribeFn: () => void) {
   console.log(`Error received from topic subscription; ${error.toString()}`);
+
+  // optionally: unsubscribe from the topic subscription
+  //unsubscribeFn();
 }
 
 main()

--- a/examples/topic-subscribe.ts
+++ b/examples/topic-subscribe.ts
@@ -20,21 +20,41 @@ async function main() {
   });
 
   console.log(`Subscribing to cacheName=${cacheName}, topicName=${topicName}`);
-  await momento.subscribe(cacheName, topicName, {
+  const response = await momento.subscribe(cacheName, topicName, {
     onItem: handleData,
     onError: handleError,
   });
+
+  if (response instanceof TopicSubscribe.Error) {
+    console.log('Error subscribing to topic subscription');
+    return;
+  } else if (response instanceof TopicSubscribe.Subscription) {
+    console.log('Successfully subscribed to topic subscription');
+
+    // Quit after 60s
+    const sleep = (seconds: number) =>
+      new Promise(r => setTimeout(r, seconds * 1000));
+    await sleep(60);
+    // test if response is instance of TopicSubscribe.Subscription
+    if (response instanceof TopicSubscribe.Subscription) {
+      console.log('Unsubscribing from topic subscription');
+      response.unsubscribe();
+    }
+  }
 }
 
 function handleData(data: TopicSubscribe.Item) {
   console.log('Data received from topic subscription; %s', data);
 }
 
-function handleError(error: TopicSubscribe.Error, unsubscribeFn: () => void) {
+function handleError(
+  error: TopicSubscribe.Error,
+  subscription: TopicSubscribe.Subscription
+) {
   console.log(`Error received from topic subscription; ${error.toString()}`);
 
   // optionally: unsubscribe from the topic subscription
-  //unsubscribeFn();
+  //subscription.unsubscribe();
 }
 
 main()

--- a/src/utils/topic-call-options.ts
+++ b/src/utils/topic-call-options.ts
@@ -15,6 +15,7 @@ export interface SubscribeCallOptions {
    * The callback to invoke when an error is received from the topic subscription.
    *
    * @param error The error received from the topic subscription.
+   * @param unsubscribeFn The function to invoke to unsubscribe from the topic subscription.
    */
-  onError(error: TopicSubscribe.Error): void;
+  onError(error: TopicSubscribe.Error, unsubscribeFn: () => void): void;
 }


### PR DESCRIPTION
Introduces pubsub examples using the latest topics client. Note that because pubsub has not been released, we are importing the node SDK from the filesystem instead of from npm.