### PR TITLE
feat: allow user to unsubscribe when receiving an error

### DIFF
--- a/src/internal/pubsub-client.ts
+++ b/src/internal/pubsub-client.ts
@@ -279,6 +279,9 @@ export class PubsubClient {
           return;
         }
 
+        // Prevent repeated calls to cancel the stream.
+        isSubscribed = false;
+
         this.logger.trace('Stream ended on topic: %s; restarting.', topicName);
         this.sendSubscribe(
           cacheName,

--- a/src/internal/pubsub-client.ts
+++ b/src/internal/pubsub-client.ts
@@ -193,15 +193,15 @@ export class PubsubClient {
    * @param {string} cacheName
    * @param {string} topicName
    * @param {SubscribeCallOptions} options
-   * @param {number} [resumeAtTopicSequenceNumber=0]
+   * @param {SubscriptionState} subscriptionState
    * @param {TopicSubscribe.Subscription} [subscription]
-   * @return {*}  {TopicSubscribe.Subscription}
+   * @return {*}  {void}
    * @memberof PubsubClient
    *
    * @remark This method is responsible for reconnecting the stream if it ends unexpectedly.
    * Since we return a single subscription object to the user, we need to update it with the
    * unsubscribe function should we restart the stream. This is why we pass the subscription
-   * object as a parameter.
+   * state and subscription object to this method.
    */
   private sendSubscribe(
     cacheName: string,

--- a/src/internal/subscription-state.ts
+++ b/src/internal/subscription-state.ts
@@ -1,0 +1,41 @@
+/**
+ * Encapsulates a topic subscription stream state.
+ */
+export class SubscriptionState {
+  private _unsubscribeFn: () => void;
+  public lastTopicSequenceNumber?: number;
+  private _isSubscribed: boolean;
+  constructor() {
+    this._unsubscribeFn = () => {
+      return;
+    };
+    this._isSubscribed = false;
+  }
+
+  public get resumeAtTopicSequenceNumber(): number {
+    return (this.lastTopicSequenceNumber ?? -1) + 1;
+  }
+
+  public setSubscribed(): void {
+    this._isSubscribed = true;
+  }
+
+  public setUnsubscribed(): void {
+    this._isSubscribed = false;
+  }
+
+  public get isSubscribed(): boolean {
+    return this._isSubscribed;
+  }
+
+  public set unsubscribeFn(unsubscribeFn: () => void) {
+    this._unsubscribeFn = unsubscribeFn;
+  }
+
+  public unsubscribe(): void {
+    if (this.isSubscribed) {
+      this._unsubscribeFn();
+      this.setUnsubscribed();
+    }
+  }
+}

--- a/src/messages/responses/topic-subscribe.ts
+++ b/src/messages/responses/topic-subscribe.ts
@@ -8,15 +8,15 @@ import {truncateString} from '../../internal/utils/display';
  * response object is resolved to a type-safe object of one of
  * the following subtypes:
  *
- * - {Hit}
- * - {Miss}
+ * - {Subscription}
+ * - {Item}
  * - {Error}
  *
  * `instanceof` type guards can be used to operate on the appropriate subtype.
  * @example
  * For example:
  * ```
- * if (response instanceof CacheGet.Error) {
+ * if (response instanceof TopicSubscribe.Error) {
  *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
  *   // `CacheGet.Error` in this block, so you will have access to the properties
  *   // of the Error class; e.g. `response.errorCode()`.
@@ -45,6 +45,44 @@ export class Item extends Response {
   }
 }
 
+/**
+ * Encapsulates a topic subscription.
+ *
+ * @remarks Currently allows unsubscribing from the topic.
+ * In the future, this may be extended to include additional
+ * statistics about the subscription.
+ */
+export class Subscription extends Response {
+  protected _unsubscribeFn: () => void;
+  private _isSubscribed: boolean;
+
+  constructor(_unsubscribeFn: () => void) {
+    super();
+    this._unsubscribeFn = _unsubscribeFn;
+    this._isSubscribed = true;
+  }
+
+  /**
+   * Unsubscribes from the topic.
+   *
+   * @returns void
+   */
+  public unsubscribe(): void {
+    if (this.isSubscribed()) {
+      this._unsubscribeFn();
+      this._isSubscribed = false;
+    }
+  }
+
+  public setUnsubscribeFn(unsubscribeFn: () => void): void {
+    this._unsubscribeFn = unsubscribeFn;
+  }
+
+  public isSubscribed(): boolean {
+    return this._isSubscribed;
+  }
+}
+
 class _Error extends Response {
   constructor(protected _innerException: SdkError) {
     super();
@@ -52,7 +90,7 @@ class _Error extends Response {
 }
 
 /**
- * Indicates that an error occurred during the cache get request.
+ * Indicates that an error occurred during the topic subscribe request.
  *
  * This response object includes the following fields that you can use to determine
  * how you would like to handle the error:

--- a/src/messages/responses/topic-subscribe.ts
+++ b/src/messages/responses/topic-subscribe.ts
@@ -2,6 +2,7 @@
 import {SdkError} from '../../errors/errors';
 import {ResponseBase, ResponseError} from './response-base';
 import {truncateString} from '../../internal/utils/display';
+import {SubscriptionState} from '../../internal/subscription-state';
 
 /**
  * Parent response type for a cache get request.  The
@@ -53,13 +54,11 @@ export class Item extends Response {
  * statistics about the subscription.
  */
 export class Subscription extends Response {
-  protected _unsubscribeFn: () => void;
-  private _isSubscribed: boolean;
+  private subscriptionState: SubscriptionState;
 
-  constructor(_unsubscribeFn: () => void) {
+  constructor(subscriptionState: SubscriptionState) {
     super();
-    this._unsubscribeFn = _unsubscribeFn;
-    this._isSubscribed = true;
+    this.subscriptionState = subscriptionState;
   }
 
   /**
@@ -68,18 +67,7 @@ export class Subscription extends Response {
    * @returns void
    */
   public unsubscribe(): void {
-    if (this.isSubscribed()) {
-      this._unsubscribeFn();
-      this._isSubscribed = false;
-    }
-  }
-
-  public setUnsubscribeFn(unsubscribeFn: () => void): void {
-    this._unsubscribeFn = unsubscribeFn;
-  }
-
-  public isSubscribed(): boolean {
-    return this._isSubscribed;
+    this.subscriptionState.unsubscribe();
   }
 }
 

--- a/src/topic-client.ts
+++ b/src/topic-client.ts
@@ -1,5 +1,5 @@
 import {PubsubClient} from './internal/pubsub-client';
-import {TopicPublish, MomentoLogger} from '.';
+import {TopicPublish, MomentoLogger, TopicSubscribe} from '.';
 import {TopicClientProps} from './topic-client-props';
 import {SubscribeCallOptions} from './utils/topic-call-options';
 
@@ -48,13 +48,15 @@ export class TopicClient {
    * @param {SubscribeCallOptions} options - The options for the subscription.
    * @param {function} options.onItem - The callback to invoke when data is received.
    * @param {function} options.onError - The callback to invoke when an error is received.
-   * @returns
+   * @returns {Promise<TopicSubscribe.Response>} -
+   * {@link TopicSubscribe.Subscription} on success.
+   * {@link TopicSubscribe.Error} on failure.
    */
   public async subscribe(
     cacheName: string,
     topicName: string,
     options: SubscribeCallOptions
-  ): Promise<void> {
+  ): Promise<TopicSubscribe.Response> {
     return await this.client.subscribe(cacheName, topicName, options);
   }
 }

--- a/src/utils/topic-call-options.ts
+++ b/src/utils/topic-call-options.ts
@@ -15,6 +15,7 @@ export interface SubscribeCallOptions {
    * The callback to invoke when an error is received from the topic subscription.
    *
    * @param error The error received from the topic subscription.
+   * @param unsubscribeFn The function to invoke to unsubscribe from the topic subscription.
    */
-  onError(error: TopicSubscribe.Error): void;
+  onError(error: TopicSubscribe.Error, unsubscribeFn: () => void): void;
 }

--- a/src/utils/topic-call-options.ts
+++ b/src/utils/topic-call-options.ts
@@ -15,7 +15,10 @@ export interface SubscribeCallOptions {
    * The callback to invoke when an error is received from the topic subscription.
    *
    * @param error The error received from the topic subscription.
-   * @param unsubscribeFn The function to invoke to unsubscribe from the topic subscription.
+   * @param subscription The subscription that received the error.
    */
-  onError(error: TopicSubscribe.Error, unsubscribeFn: () => void): void;
+  onError(
+    error: TopicSubscribe.Error,
+    subscription: TopicSubscribe.Subscription
+  ): void;
 }


### PR DESCRIPTION
In the prior PR, the user had no mechanism to unsubscribe / cancel the
stream. In this PR we allow the user to unsubscribe via the subscription response.
We return the response from `subscribe` and also pass it as an argument to the error handler.

See [here](https://github.com/momentohq/client-sdk-nodejs/pull/350/commits/6b6d0268087b66a3cf4449c5f11d232501099cba) for the examples.