### PR TITLE
fix: orphaned UUID caches

### DIFF
--- a/test/integration/get-set-delete.test.ts
+++ b/test/integration/get-set-delete.test.ts
@@ -14,7 +14,8 @@ import {
   ValidateCacheProps,
   IntegrationTestCacheClientProps,
   ItBehavesLikeItValidatesCacheName,
-  WithCache, testCacheName,
+  WithCache,
+  testCacheName,
 } from './integration-setup';
 import {sleep} from '../../src/internal/utils/sleep';
 

--- a/test/integration/get-set-delete.test.ts
+++ b/test/integration/get-set-delete.test.ts
@@ -14,7 +14,7 @@ import {
   ValidateCacheProps,
   IntegrationTestCacheClientProps,
   ItBehavesLikeItValidatesCacheName,
-  WithCache,
+  WithCache, testCacheName,
 } from './integration-setup';
 import {sleep} from '../../src/internal/utils/sleep';
 
@@ -115,7 +115,7 @@ describe('get/set/delete', () => {
   });
 
   it('should timeout on a request that exceeds specified timeout', async () => {
-    const cacheName = v4();
+    const cacheName = testCacheName();
     const defaultTimeoutClient = Momento;
     const shortTimeoutTransportStrategy =
       IntegrationTestCacheClientProps.configuration
@@ -412,7 +412,7 @@ describe('#setIfNotExists', () => {
   });
 
   it('should timeout on a request that exceeds specified timeout', async () => {
-    const cacheName = v4();
+    const cacheName = testCacheName();
     const defaultTimeoutClient = Momento;
     const shortTimeoutTransportStrategy =
       IntegrationTestCacheClientProps.configuration

--- a/test/integration/integration-setup.ts
+++ b/test/integration/integration-setup.ts
@@ -14,7 +14,7 @@ import {
   ResponseBase,
 } from '../../src/messages/responses/response-base';
 
-function testCacheName(): string {
+export function testCacheName(): string {
   const name = process.env.TEST_CACHE_NAME || 'js-integration-test-default';
   return name + v4();
 }


### PR DESCRIPTION
This commit fixes a few places where we were still creating
caches in tests that only had UUIDs for their names.  Also fixes
a few tests where we were orphaning those caches after the
tests completed.
