### PR TITLE
fix: wait for first response on pubsub and also check for cache deleted midstream

### DIFF
--- a/src/internal/pubsub-client.ts
+++ b/src/internal/pubsub-client.ts
@@ -55,9 +55,9 @@ export class PubsubClient {
       .getTransportStrategy()
       .getGrpcConfig();
 
+    this.validateRequestTimeout(grpcConfig.getDeadlineMillis());
     this.unaryRequestTimeoutMs =
       grpcConfig.getDeadlineMillis() || PubsubClient.DEFAULT_REQUEST_TIMEOUT_MS;
-    this.validateRequestTimeout(this.unaryRequestTimeoutMs);
     this.logger.debug(
       `Creating topic client using endpoint: '${this.credentialProvider.getCacheEndpoint()}'`
     );
@@ -102,7 +102,7 @@ export class PubsubClient {
 
   private validateRequestTimeout(timeout?: number) {
     this.logger.debug(`Request timeout ms: ${String(timeout)}`);
-    if (timeout && timeout <= 0) {
+    if (timeout !== undefined && timeout <= 0) {
       throw new InvalidArgumentError(
         'request timeout must be greater than zero.'
       );

--- a/src/internal/utils/validators.ts
+++ b/src/internal/utils/validators.ts
@@ -80,6 +80,20 @@ export function validateListSliceStartEnd(
   }
 }
 
+export function validateTopicName(name: string) {
+  if (isEmpty(name)) {
+    throw new InvalidArgumentError('topic name must not be empty');
+  }
+}
+
+export function validateTopicValue(value: string | Uint8Array) {
+  if (typeof value === 'string') {
+    if (isEmpty(value)) {
+      throw new InvalidArgumentError('value must not be empty');
+    }
+  }
+}
+
 export function validateTtlMinutes(ttlMinutes: number) {
   if (ttlMinutes < 0) {
     throw new InvalidArgumentError('ttlMinutes must be positive');

--- a/src/messages/responses/topic-subscribe.ts
+++ b/src/messages/responses/topic-subscribe.ts
@@ -33,11 +33,27 @@ export class Item extends Response {
     this._value = _value;
   }
   /**
-   * Returns the data as a utf-8 string, decoded from the underlying byte array.
-   * @returns string
+   * Returns the data read from the stream.
+   * @returns string | Uint8Array
    */
   public value(): string | Uint8Array {
     return this._value;
+  }
+
+  /**
+   * Returns the data read from the stream as a string.
+   * @returns string
+   */
+  public valueString(): string {
+    return this.value().toString();
+  }
+
+  /**
+   * Returns the data read from the stream as a Uint8Array.
+   * @returns Uint8Array
+   */
+  public valueUint8Array(): Uint8Array {
+    return this.value() as Uint8Array;
   }
 
   public override toString(): string {

--- a/src/messages/responses/topic-subscribe.ts
+++ b/src/messages/responses/topic-subscribe.ts
@@ -85,6 +85,10 @@ export class Subscription extends Response {
   public unsubscribe(): void {
     this.subscriptionState.unsubscribe();
   }
+
+  public get isSubscribed(): boolean {
+    return this.subscriptionState.isSubscribed;
+  }
 }
 
 class _Error extends Response {

--- a/src/topic-client.ts
+++ b/src/topic-client.ts
@@ -46,8 +46,8 @@ export class TopicClient {
    * @param {string} cacheName - The name of the cache to containing the topic to subscribe to.
    * @param {string} topicName - The name of the topic to subscribe to.
    * @param {SubscribeCallOptions} options - The options for the subscription. Defaults to no-op handlers.
-   * @param {function} options.onItem - The callback to invoke when data is received.
-   * @param {function} options.onError - The callback to invoke when an error is received.
+   * @param {function} options.onItem - The callback to invoke when data is received. Defaults to no-op.
+   * @param {function} options.onError - The callback to invoke when an error is received. Defaults to no-op.
    * @returns {Promise<TopicSubscribe.Response>} -
    * {@link TopicSubscribe.Subscription} on success.
    * {@link TopicSubscribe.Error} on failure.

--- a/src/topic-client.ts
+++ b/src/topic-client.ts
@@ -45,7 +45,7 @@ export class TopicClient {
    *
    * @param {string} cacheName - The name of the cache to containing the topic to subscribe to.
    * @param {string} topicName - The name of the topic to subscribe to.
-   * @param {SubscribeCallOptions} options - The options for the subscription.
+   * @param {SubscribeCallOptions} options - The options for the subscription. Defaults to no-op handlers.
    * @param {function} options.onItem - The callback to invoke when data is received.
    * @param {function} options.onError - The callback to invoke when an error is received.
    * @returns {Promise<TopicSubscribe.Response>} -
@@ -55,7 +55,7 @@ export class TopicClient {
   public async subscribe(
     cacheName: string,
     topicName: string,
-    options: SubscribeCallOptions
+    options: SubscribeCallOptions = {}
   ): Promise<TopicSubscribe.Response> {
     return await this.client.subscribe(cacheName, topicName, options);
   }

--- a/src/utils/topic-call-options.ts
+++ b/src/utils/topic-call-options.ts
@@ -9,7 +9,7 @@ export interface SubscribeCallOptions {
    *
    * @param data The data received from the topic subscription.
    */
-  onItem(data: TopicSubscribe.Item): void;
+  onItem?: (data: TopicSubscribe.Item) => void;
 
   /**
    * The callback to invoke when an error is received from the topic subscription.
@@ -17,8 +17,8 @@ export interface SubscribeCallOptions {
    * @param error The error received from the topic subscription.
    * @param subscription The subscription that received the error.
    */
-  onError(
+  onError?: (
     error: TopicSubscribe.Error,
     subscription: TopicSubscribe.Subscription
-  ): void;
+  ) => void;
 }

--- a/test/integration/integration-setup.ts
+++ b/test/integration/integration-setup.ts
@@ -125,5 +125,8 @@ export function ItBehavesLikeItValidatesCacheName(
     expect((response as IResponseError).errorCode()).toEqual(
       MomentoErrorCode.INVALID_ARGUMENT_ERROR
     );
+    expect((response as IResponseError).message()).toEqual(
+      'Invalid argument passed to Momento client: cache name must not be empty'
+    );
   });
 }

--- a/test/integration/topic-client.test.ts
+++ b/test/integration/topic-client.test.ts
@@ -125,21 +125,10 @@ describe('#subscribe', () => {
   });
 
   it('should error when subscribing to a cache that does not exist and unsubscribe from the error handler', async () => {
-    await topicClient.subscribe(v4(), 'topic', {
-      onItem: () => {
-        return;
-      },
-      onError: (
-        error: TopicSubscribe.Error,
-        subscription: TopicSubscribe.Subscription
-      ) => {
-        expect(error.errorCode()).toEqual(MomentoErrorCode.NOT_FOUND_ERROR);
-        expect(error.message()).toEqual(
-          'A cache with the specified name does not exist.  To resolve this error, make sure you have created the cache before attempting to use it: 5 NOT_FOUND: Cache not found'
-        );
-        subscription.unsubscribe();
-      },
-    });
+    const response = await topicClient.subscribe(v4(), 'topic');
+    expect((response as IResponseError).errorCode()).toEqual(
+      MomentoErrorCode.NOT_FOUND_ERROR
+    );
   });
 });
 

--- a/test/integration/topic-client.test.ts
+++ b/test/integration/topic-client.test.ts
@@ -1,5 +1,7 @@
 import {v4} from 'uuid';
 import {
+  CreateCache,
+  DeleteCache,
   TopicClient,
   MomentoErrorCode,
   TopicPublish,
@@ -20,7 +22,7 @@ import {
 import {SubscribeCallOptions} from '../../src/utils/topic-call-options';
 import {sleep} from '../../src/internal/utils/sleep';
 
-const {IntegrationTestCacheName} = SetupIntegrationTest();
+const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
 const topicClient = new TopicClient({
   configuration: IntegrationTestCacheClientProps.configuration,
   credentialProvider: IntegrationTestCacheClientProps.credentialProvider,
@@ -238,5 +240,61 @@ describe('subscribe and publish', () => {
     );
     expect(subscribeResponse).toBeInstanceOf(TopicSubscribe.Subscription);
     (subscribeResponse as TopicSubscribe.Subscription).unsubscribe();
+  });
+
+  it('should unsubscribe automatically if the cache is deleted mid-subscription', async () => {
+    const randomCacheName = v4();
+    const createCacheResponse = await Momento.createCache(randomCacheName);
+    let subscribeResponse: TopicSubscribe.Response | undefined;
+
+    try {
+      expect(createCacheResponse).toBeInstanceOf(CreateCache.Success);
+
+      const subscribeResponse = await topicClient.subscribe(
+        randomCacheName,
+        v4(),
+        {
+          onItem: (item: TopicSubscribe.Item) => {
+            expect(1).fail(
+              `Should not receive an item but got one: ${item.toString()}`
+            );
+          },
+          onError: (
+            error: TopicSubscribe.Error,
+            subscription: TopicSubscribe.Subscription
+          ) => {
+            expect(error.errorCode()).toEqual(MomentoErrorCode.NOT_FOUND_ERROR);
+            expect(subscription.isSubscribed).toBeFalse();
+          },
+        }
+      );
+      expect(subscribeResponse).toBeInstanceOf(TopicSubscribe.Subscription);
+
+      // Wait for stream to start.
+      await sleep(STREAM_WAIT_TIME_MS);
+
+      // Pull the rug out from under the subscription.
+      const deleteCacheResponse = await Momento.deleteCache(randomCacheName);
+      expect(deleteCacheResponse).toBeInstanceOf(DeleteCache.Success);
+
+      // Wait for the subscription error handler to run.
+      await sleep(STREAM_WAIT_TIME_MS);
+    } finally {
+      // Just in case
+      const deleteCacheResponse = await Momento.deleteCache(randomCacheName);
+      if (deleteCacheResponse instanceof DeleteCache.Error) {
+        expect(deleteCacheResponse.errorCode()).toBe(
+          MomentoErrorCode.NOT_FOUND_ERROR
+        );
+      }
+
+      // Just in case
+      if (
+        subscribeResponse !== undefined &&
+        subscribeResponse instanceof TopicSubscribe.Subscription
+      ) {
+        subscribeResponse.unsubscribe();
+      }
+    }
   });
 });

--- a/test/integration/topic-client.test.ts
+++ b/test/integration/topic-client.test.ts
@@ -239,4 +239,15 @@ describe('subscribe and publish', () => {
     // Need to close the stream before the test ends or else the test will hang.
     (subscribeResponse as TopicSubscribe.Subscription).unsubscribe();
   });
+
+  it('should subscribe with default handlers', async () => {
+    const topicName = v4();
+
+    const subscribeResponse = await topicClient.subscribe(
+      IntegrationTestCacheName,
+      topicName
+    );
+    expect(subscribeResponse).toBeInstanceOf(TopicSubscribe.Subscription);
+    (subscribeResponse as TopicSubscribe.Subscription).unsubscribe();
+  });
 });

--- a/test/integration/topic-client.test.ts
+++ b/test/integration/topic-client.test.ts
@@ -30,6 +30,8 @@ interface ValidateTopicProps {
   topicName: string;
 }
 
+const STREAM_WAIT_TIME_MS = 2000;
+
 function ItBehavesLikeItValidatesTopicName(
   getResponse: (props: ValidateTopicProps) => Promise<ResponseBase>
 ) {
@@ -171,7 +173,7 @@ describe('subscribe and publish', () => {
     expect(subscribeResponse).toBeInstanceOf(TopicSubscribe.Subscription);
 
     // Wait for stream to start.
-    await sleep(1000);
+    await sleep(STREAM_WAIT_TIME_MS);
 
     for (const value of publishedValues) {
       const publishResponse = await topicClient.publish(
@@ -183,7 +185,7 @@ describe('subscribe and publish', () => {
     }
 
     // Wait for values to be received.
-    await sleep(1000);
+    await sleep(STREAM_WAIT_TIME_MS);
 
     expect(receivedValues).toEqual(publishedValues);
     done = true;
@@ -217,7 +219,7 @@ describe('subscribe and publish', () => {
     expect(subscribeResponse).toBeInstanceOf(TopicSubscribe.Subscription);
 
     // Wait for stream to start.
-    await sleep(1000);
+    await sleep(STREAM_WAIT_TIME_MS);
     // Unsubscribing before data is published should not receive any data.
     (subscribeResponse as TopicSubscribe.Subscription).unsubscribe();
 
@@ -229,7 +231,7 @@ describe('subscribe and publish', () => {
     expect(publishResponse).toBeInstanceOf(TopicPublish.Response);
 
     // Wait for values to go over the network.
-    await sleep(1000);
+    await sleep(STREAM_WAIT_TIME_MS);
 
     expect(receivedValues).toEqual([]);
     done = true;

--- a/test/integration/topic-client.test.ts
+++ b/test/integration/topic-client.test.ts
@@ -44,13 +44,13 @@ function ItBehavesLikeItValidatesTopicName(
   });
 }
 
-describe('topic client', () => {
-  it('should be throw an error for an invalid request timeout', () => {
+function ItBehavesLikeItValidatesRequestTimeout(requestTimeout: number) {
+  it(`should be throw an error for an invalid request timeout (requestTimeout=${requestTimeout})`, () => {
     expect(() => {
       new TopicClient({
         configuration:
           IntegrationTestCacheClientProps.configuration.withClientTimeoutMillis(
-            -1
+            requestTimeout
           ),
         credentialProvider: IntegrationTestCacheClientProps.credentialProvider,
       });
@@ -58,6 +58,11 @@ describe('topic client', () => {
       new InvalidArgumentError('request timeout must be greater than zero.')
     );
   });
+}
+
+describe('topic client constructor', () => {
+  ItBehavesLikeItValidatesRequestTimeout(0);
+  ItBehavesLikeItValidatesRequestTimeout(-1);
 });
 
 describe('#publish', () => {

--- a/test/integration/topic-client.test.ts
+++ b/test/integration/topic-client.test.ts
@@ -4,6 +4,7 @@ import {
   MomentoErrorCode,
   TopicPublish,
   TopicSubscribe,
+  InvalidArgumentError,
 } from '../../src';
 import {
   SetupIntegrationTest,
@@ -42,6 +43,22 @@ function ItBehavesLikeItValidatesTopicName(
     );
   });
 }
+
+describe('topic client', () => {
+  it('should be throw an error for an invalid request timeout', () => {
+    expect(() => {
+      new TopicClient({
+        configuration:
+          IntegrationTestCacheClientProps.configuration.withClientTimeoutMillis(
+            -1
+          ),
+        credentialProvider: IntegrationTestCacheClientProps.credentialProvider,
+      });
+    }).toThrowError(
+      new InvalidArgumentError('request timeout must be greater than zero.')
+    );
+  });
+});
 
 describe('#publish', () => {
   ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {


### PR DESCRIPTION
- docs: tweak documentation
- test: test the topic client
- test: validate request timeout
- test: topic client request timeout
- fix: increase wait time for CI server
- chore: add default handlers for pubsub subscribe
- docs: update subscribe documentation
- fix: error from subscribe immediately when a cache doesnt exist
- fix: cancel the stream if the cache is deleted midstream
