### PR TITLE
chore: allow passing of dynamic credentials provider to web sdk

### DIFF
--- a/packages/client-sdk-web/src/cache-client.ts
+++ b/packages/client-sdk-web/src/cache-client.ts
@@ -4,14 +4,18 @@ import {ControlClient} from './internal/control-client';
 import {NoopMomentoLoggerFactory} from '@gomomento/core/dist/src/config/logging';
 import {CredentialProvider} from '@gomomento/core';
 
+export interface CacheClientProps {
+  credentialProvider: CredentialProvider;
+}
+
 export class CacheClient extends AbstractCacheClient {
-  constructor() {
-    const controlClient: IControlClient = createControlClient();
+  constructor(props: CacheClientProps) {
+    const controlClient: IControlClient = createControlClient(props);
     super(controlClient);
   }
 }
 
-function createControlClient(): IControlClient {
+function createControlClient(props: CacheClientProps): IControlClient {
   return new ControlClient({
     // TODO
     // TODO
@@ -21,8 +25,6 @@ function createControlClient(): IControlClient {
     configuration: {
       getLoggerFactory: () => new NoopMomentoLoggerFactory(),
     },
-    credentialProvider: CredentialProvider.fromEnvironmentVariable({
-      environmentVariableName: 'TEST_AUTH_TOKEN',
-    }),
+    credentialProvider: props.credentialProvider,
   });
 }

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -3,10 +3,14 @@ import {
   deleteCacheIfExists,
   testCacheName,
 } from '@gomomento/common-integration-tests';
-import {CreateCache, DeleteCache} from '@gomomento/core';
+import {CreateCache, CredentialProvider, DeleteCache} from '@gomomento/core';
 
 function momentoClientForTesting() {
-  return new CacheClient();
+  return new CacheClient({
+    credentialProvider: CredentialProvider.fromEnvironmentVariable({
+      environmentVariableName: 'TEST_AUTH_TOKEN',
+    }),
+  });
 }
 
 export function SetupIntegrationTest(): {


### PR DESCRIPTION
We will need to pass something along the lines of 

```
CredentialProvider.fromString({
      authToken: "token",
      controlEndpoint: 'control.<endpoint>',
      cacheEndpoint: 'data.<endpoint>'
    })
```

Eventually might be nice to have some kind of session token provider, however since we are still messing with what these tokens look like I want to hold off on creating that class