### PR TITLE
fix: pass other errors to user's subscribe error handler

### DIFF
--- a/src/internal/pubsub-client.ts
+++ b/src/internal/pubsub-client.ts
@@ -400,6 +400,8 @@ export class PubsubClient {
         options.subscription.unsubscribe();
         options.onError(momentoError, options.subscription);
         return;
+      } else {
+        options.onError(momentoError, options.subscription);
       }
     };
   }


### PR DESCRIPTION
Prior to this we only passed `NOT_FOUND` gRPC errors to the user's error handler. We should invoke the error handlers on other errors but not subscribe.