### PR TITLE
fix: how we are encoding base64 strings

### DIFF
--- a/packages/common/src/internal/utils/string.ts
+++ b/packages/common/src/internal/utils/string.ts
@@ -1,3 +1,3 @@
 export const decodeFromBase64 = (base64: string) => atob(base64);
 
-export const encodeToBase64 = (str: string) => btoa(base64);
+export const encodeToBase64 = (str: string) => btoa(str);

--- a/packages/common/src/internal/utils/string.ts
+++ b/packages/common/src/internal/utils/string.ts
@@ -1,5 +1,3 @@
-export const decodeFromBase64 = (base64: string) =>
-  Buffer.from(base64, 'base64').toString();
+export const decodeFromBase64 = (base64: string) => atob(base64);
 
-export const encodeToBase64 = (str: string) =>
-  Buffer.from(str).toString('base64');
+export const encodeToBase64 = (str: string) => btoa(base64);


### PR DESCRIPTION
`Buffer` does not exist in the web environment. We should use the `Buffer` class in a nodejs env, and use btoa for a web environment