### PR TITLE
feat: publish core package to npm.js

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -48,46 +48,9 @@ jobs:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Test
-        run: npm run test
-
-      - name: Publish package to npm
+      - name: Publish all packages to npm
         run: |
-          export VERSION="${{ needs.release.outputs.version }}"
-          echo "Publishing package with version $VERSION"
-          mv package.json package.json.ORIG
-          cat package.json.ORIG|jq ". += {\"version\": \"$VERSION\"}" > package.json
-          npm publish
+          ./scripts/publish-all-packages.sh
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-
-      - name: Configure AWS credentials for public artifacts account
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: arn:aws:iam::537451838446:role/public-cicd-remote-deployer
-          aws-region: us-west-2
-          aws-access-key-id: ${{ secrets.PUBLIC_CICD_DEPLOYER_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PUBLIC_CICD_DEPLOYER_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 1200
-          role-session-name: javascript-sdk-lambda-layer-deployer
-          role-skip-session-tagging: true
-
-      - name: Publish lambda layer
-        run: |
-          export VERSION="${{ needs.release.outputs.version }}"
-          echo "Publishing lambda layer with version $VERSION"
-          pushd build-scripts
-            ./build-lambda-layer.sh
-            ./publish-lambda-layer.sh ${VERSION}
-          popd
-        shell: bash

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Publish all packages to npm
         run: |
-          ./scripts/publish-all-packages.sh
+          ./scripts/publish-all-packages.sh "${{ needs.release.outputs.version }}"
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gomomento/core",
-  "version": "0.0.1000",
+  "version": "0.0.1",
   "description": "Common code for Momento JS SDKs",
   "main": "dist/src/index.js",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gomomento/core",
-  "version": "0.0.1",
+  "version": "0.0.1000",
   "description": "Common code for Momento JS SDKs",
   "main": "dist/src/index.js",
   "files": [

--- a/scripts/build-all-packages.sh
+++ b/scripts/build-all-packages.sh
@@ -5,7 +5,7 @@ set -e
 
 ROOT_DIR="$(dirname "$0")/.."
 
-echo "dev building web sdk"
+echo "building all packages"
 
 ${ROOT_DIR}/scripts/build-package.sh "core"
 ${ROOT_DIR}/scripts/build-package.sh "common-integration-tests"

--- a/scripts/publish-all-packages.sh
+++ b/scripts/publish-all-packages.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -x
+set -e
+
+ROOT_DIR="$(dirname "$0")/.."
+
+echo "publishing all packages"
+
+${ROOT_DIR}/scripts/publish-package.sh "core"

--- a/scripts/publish-all-packages.sh
+++ b/scripts/publish-all-packages.sh
@@ -8,7 +8,8 @@ usage() {
 }
 
 VERSION=${1}
-if [ "${VERSION}" == "" ];
+if [ "${VERSION}" == "" ]
+then
    echo "Missing required argument: VERSION"
    usage
    exit 1

--- a/scripts/publish-all-packages.sh
+++ b/scripts/publish-all-packages.sh
@@ -3,8 +3,19 @@
 set -x
 set -e
 
+usage() {
+   echo "Usage: $0 <VERSION>"
+}
+
+VERSION=${1}
+if [ "${VERSION}" == "" ];
+   echo "Missing required argument: VERSION"
+   usage
+   exit 1
+fi
+
 ROOT_DIR="$(dirname "$0")/.."
 
 echo "publishing all packages"
 
-${ROOT_DIR}/scripts/publish-package.sh "core"
+${ROOT_DIR}/scripts/publish-package.sh "core" "${VERSION}"

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -x
+set -e
+
+usage() {
+   echo "Usage: $0 <PACKAGE> <VERSION>"
+}
+
+ROOT_DIR="$(dirname "$0")/.."
+
+PACKAGE=${1}
+if [ "${PACKAGE}" == "" ];
+   echo "Missing required argument: PACKAGE"
+   usage
+   exit 1
+fi
+
+VERSION=${2}
+if [ "${VERSION}" == "" ];
+   echo "Missing required argument: VERSION"
+   usage
+   exit 1
+fi
+
+echo "publishing package: ${PACKAGE} with version ${VERSION}"
+
+pushd ${ROOT_DIR}/packages/${PACKAGE}
+    npm ci
+    npm run build
+    npm run lint
+    npm run test
+    mv package.json package.json.ORIG
+    cat package.json.ORIG |jq ". += {\"version\": \"${VERSION}\"}" > package.json
+    npm publish
+popd

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -10,14 +10,16 @@ usage() {
 ROOT_DIR="$(dirname "$0")/.."
 
 PACKAGE=${1}
-if [ "${PACKAGE}" == "" ];
+if [ "${PACKAGE}" == "" ]
+then
    echo "Missing required argument: PACKAGE"
    usage
    exit 1
 fi
 
 VERSION=${2}
-if [ "${VERSION}" == "" ];
+if [ "${VERSION}" == "" ]
+then
    echo "Missing required argument: VERSION"
    usage
    exit 1


### PR DESCRIPTION
This commit adds shell scripts to simplify the steps for publishing
to npm.js.  As of this commit, the release process should only
release the `core` package.  Since nothing will be consuming it
yet, this should be harmless.  In subsequent commits we will

* add polling to wait for the publish to complete
* publish the nodejs package with a dep on the newly published
  core package
* figure out pre-1.0 versioning for the web sdk package
* publish the web sdk package.
