### PR TITLE
fix: pass 'public' flag to npm publish

### DIFF
--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -34,5 +34,5 @@ pushd ${ROOT_DIR}/packages/${PACKAGE}
     npm run test
     mv package.json package.json.ORIG
     cat package.json.ORIG |jq ". += {\"version\": \"${VERSION}\"}" > package.json
-    npm publish
+    npm publish --access public
 popd


### PR DESCRIPTION
At some point recently npm.js started requiring you to pass
the 'public' access flag to publish public packages, otherwise
the publish fails with an error about how you have to pay for
private packages.
