### PR TITLE
chore: fix order of updating package.json for publish

### DIFF
--- a/scripts/publish-all-packages.sh
+++ b/scripts/publish-all-packages.sh
@@ -21,4 +21,5 @@ echo "publishing all packages"
 
 ${ROOT_DIR}/scripts/publish-package.sh "core" "${VERSION}"
 ${ROOT_DIR}/scripts/wait-for-npmjs-release.sh "@gomomento/core" "${VERSION}"
+${ROOT_DIR}/scripts/build-package.sh "common-integration-tests"
 ${ROOT_DIR}/scripts/publish-package.sh "client-sdk-nodejs" "${VERSION}"

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -28,15 +28,20 @@ fi
 echo "publishing package: ${PACKAGE} with version ${VERSION}"
 
 pushd ${ROOT_DIR}/packages/${PACKAGE}
-    npm ci
-    npm run build
-    npm run lint
-    npm run test
     mv package.json package.json.ORIG
     # We need to update the version number of the package itself; Also, if it has a dependency on @gomomento/core, then
     # we need to update that dependency version too.
     cat package.json.ORIG | \
       jq ". += {\"version\": \"${VERSION}\"} | if .dependencies.\"@gomomento/core\"? then .dependencies.\"@gomomento/core\"=\"${VERSION}\" else . end" \
       > package.json
+    echo ""
+    echo "New package.json:"
+    cat package.json
+    echo ""
+    npm ci
+    npm run build
+    npm run lint
+    npm run test
+
     npm publish --access public
 popd


### PR DESCRIPTION
Prior to this commit we weren't updating the package.json
files until after we ran tests and such, which is not the
right order to do it.

We were also missing a build step for building the common
integration tests before publishing the node.js sdk.
