### PR TITLE
fix: change error type to concrete type rather than `object`

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/data-client.ts
@@ -49,7 +49,6 @@ import {
   CollectionTtl,
   UnknownError,
   SortedSetOrder,
-  SdkError,
   MomentoLoggerFactory,
 } from '..';
 import {version} from '../../package.json';
@@ -2259,7 +2258,7 @@ export class DataClient {
       return new CacheSortedSetGetScore.Miss(this.convert(value));
     } else if (responses instanceof CacheSortedSetGetScores.Error) {
       return new CacheSortedSetGetScore.Error(
-        <SdkError>responses.innerException(),
+        responses.innerException(),
         this.convert(value)
       );
     }

--- a/packages/core/src/messages/responses/response-base.ts
+++ b/packages/core/src/messages/responses/response-base.ts
@@ -14,7 +14,7 @@ type Constructor = new (...args: any[]) => {};
 // They are not for public consumption.
 export interface IResponseError {
   message(): string;
-  innerException(): object;
+  innerException(): SdkError;
   errorCode(): MomentoErrorCode;
   toString(): string;
 }
@@ -39,7 +39,7 @@ export function ResponseError<TBase extends Constructor>(Base: TBase) {
       return this._innerException.wrappedErrorMessage();
     }
 
-    public innerException(): object {
+    public innerException(): SdkError {
       return this._innerException;
     }
 


### PR DESCRIPTION
A user noticed that our `innerException` signatures were declaring
that they returned `object`, when in actuality they always return
an SdkError.  This commit fixes the signature so that end users
can do more useful things with the Errors.
