### PR TITLE
fix: core dependency version for web sdk

### DIFF
--- a/scripts/publish-all-packages.sh
+++ b/scripts/publish-all-packages.sh
@@ -14,15 +14,16 @@ then
    usage
    exit 1
 fi
+CORE_VERSION=$VERSION
 
 ROOT_DIR="$(dirname "$0")/.."
 
 echo "publishing all packages"
 
-${ROOT_DIR}/scripts/publish-package.sh "core" "${VERSION}"
+${ROOT_DIR}/scripts/publish-package.sh "core" "${CORE_VERSION}" "${CORE_VERSION}"
 ${ROOT_DIR}/scripts/wait-for-npmjs-release.sh "@gomomento/core" "${VERSION}"
 ${ROOT_DIR}/scripts/build-package.sh "common-integration-tests"
-${ROOT_DIR}/scripts/publish-package.sh "client-sdk-nodejs" "${VERSION}"
+${ROOT_DIR}/scripts/publish-package.sh "client-sdk-nodejs" "${VERSION}" "${CORE_VERSION}"
 
 # We plan to version the web SDK along with the node.js SDK and core library for the time
 # being, just to keep things simple.
@@ -30,4 +31,4 @@ ${ROOT_DIR}/scripts/publish-package.sh "client-sdk-nodejs" "${VERSION}"
 # the leading `1.` in the version number with a `0.`, to make it clear that we are pre-`1.0`.
 # We will remove this line when we are ready to officially release the web sdk.
 WEB_SDK_VERSION=$(echo ${VERSION} |sed "s/^1\./0\./")
-${ROOT_DIR}/scripts/publish-package.sh "client-sdk-web" "${WEB_SDK_VERSION}"
+${ROOT_DIR}/scripts/publish-package.sh "client-sdk-web" "${WEB_SDK_VERSION}" "${CORE_VERSION}"

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -4,7 +4,7 @@ set -x
 set -e
 
 usage() {
-   echo "Usage: $0 <PACKAGE> <VERSION>"
+   echo "Usage: $0 <PACKAGE> <VERSION> <CORE_VERSION>"
 }
 
 ROOT_DIR="$(dirname "$0")/.."
@@ -25,14 +25,22 @@ then
    exit 1
 fi
 
-echo "publishing package: ${PACKAGE} with version ${VERSION}"
+CORE_VERSION=${3}
+if [ "${CORE_VERSION}" == "" ]
+then
+   echo "Missing required argument: CORE_VERSION"
+   usage
+   exit 1
+fi
+
+echo "publishing package: ${PACKAGE} with version ${VERSION} (core version: ${CORE_VERSION})"
 
 pushd ${ROOT_DIR}/packages/${PACKAGE}
     mv package.json package.json.ORIG
     # We need to update the version number of the package itself; Also, if it has a dependency on @gomomento/core, then
     # we need to update that dependency version too.
     cat package.json.ORIG | \
-      jq ". += {\"version\": \"${VERSION}\"} | if .dependencies.\"@gomomento/core\"? then .dependencies.\"@gomomento/core\"=\"${VERSION}\" else . end" \
+      jq ". += {\"version\": \"${VERSION}\"} | if .dependencies.\"@gomomento/core\"? then .dependencies.\"@gomomento/core\"=\"${CORE_VERSION}\" else . end" \
       > package.json
     echo ""
     echo "New package.json:"


### PR DESCRIPTION
The web SDK publish script is modifying the version number for
pre-1.0 releases for now, but prior to this commit it was also
using that same munged version number for specifying it's
dependency on @gomomento/core.  We need to use the real version
number for the core dependency; this commit updates the scripts
to require two version arguments, one for the package version
and one for the core dependency version.
