### PR TITLE
fix: verify response types before casting them

### DIFF
--- a/packages/common-integration-tests/src/list.ts
+++ b/packages/common-integration-tests/src/list.ts
@@ -107,6 +107,7 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect(
           (respFetch as CacheListFetch.Hit).valueListString()
         ).toIncludeAllMembers(values);
@@ -155,6 +156,7 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values
         );
@@ -177,6 +179,7 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual([
           'two',
           'three',
@@ -206,6 +209,7 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values.reverse()
         );
@@ -228,6 +232,7 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual([
           'three',
           'two',
@@ -259,12 +264,20 @@ export function runListTests(
           valueString
         );
 
-        const respFetch = <CacheListFetch.Hit>(
-          await Momento.listFetch(IntegrationTestCacheName, listName)
+        const respFetch = await Momento.listFetch(
+          IntegrationTestCacheName,
+          listName
         );
-        expect(respFetch.valueListString()).toEqual([valueString]);
-        expect(respFetch.valueList()).toEqual([valueString]);
-        expect(respFetch.valueListUint8Array()).toEqual([valueBytes]);
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual([
+          valueString,
+        ]);
+        expect((respFetch as CacheListFetch.Hit).valueList()).toEqual([
+          valueString,
+        ]);
+        expect((respFetch as CacheListFetch.Hit).valueListUint8Array()).toEqual(
+          [valueBytes]
+        );
       });
 
       it('returns a sliced hit if the list exists', async () => {
@@ -483,6 +496,7 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           expectedValues
         );
@@ -537,6 +551,7 @@ export function runListTests(
           await Momento.listFetch(IntegrationTestCacheName, listName)
         );
 
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect(respFetch.valueListString()).toEqual(valueStringExpected);
         expect(respFetch.valueList()).toEqual(valueStringExpected);
         expect(respFetch.valueListUint8Array()).toEqual([valueBytesExpected]);
@@ -572,6 +587,7 @@ export function runListTests(
           listName,
           values1
         );
+        expect(respConcat).toBeInstanceOf(CacheListConcatenateBack.Success);
         expect(
           (respConcat as CacheListConcatenateBack.Success).listLength()
         ).toEqual(values1.length);
@@ -580,6 +596,7 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values1
         );
@@ -589,11 +606,13 @@ export function runListTests(
           listName,
           values2
         );
+        expect(respConcat).toBeInstanceOf(CacheListConcatenateBack.Success);
         expect(
           (respConcat as CacheListConcatenateBack.Success).listLength()
         ).toEqual(values1.length + values2.length);
 
         respFetch = await Momento.listFetch(IntegrationTestCacheName, listName);
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values1.concat(values2)
         );
@@ -629,6 +648,7 @@ export function runListTests(
           listName,
           values1
         );
+        expect(respConcat).toBeInstanceOf(CacheListConcatenateFront.Success);
         expect(
           (respConcat as CacheListConcatenateFront.Success).listLength()
         ).toEqual(values1.length);
@@ -637,6 +657,7 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values1
         );
@@ -646,11 +667,13 @@ export function runListTests(
           listName,
           values2
         );
+        expect(respConcat).toBeInstanceOf(CacheListConcatenateFront.Success);
         expect(
           (respConcat as CacheListConcatenateFront.Success).listLength()
         ).toEqual(values1.length + values2.length);
 
         respFetch = await Momento.listFetch(IntegrationTestCacheName, listName);
+        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values2.concat(values1)
         );


### PR DESCRIPTION
We have seen some transient build errors that look like

```
    TypeError: respFetch.valueListString is not a function

      109 |         );
      110 |         expect(
    > 111 |           (respFetch as CacheListFetch.Hit).valueListString()
          |                                             ^
      112 |         ).toIncludeAllMembers(values);
      113 |       });
      114 |     };

      at Object.<anonymous> (../common-integration-tests/src/list.ts:111:45)
```

This is happening because in our integration tests, we are casting the response type before asserting the type of the response. This pr fixes this by asserting the response is of the right type before casting and verifying the contents of the response