### PR TITLE
fix: don't import text encoder from utils

### DIFF
--- a/packages/client-sdk-web/src/internal/data-client.ts
+++ b/packages/client-sdk-web/src/internal/data-client.ts
@@ -53,7 +53,6 @@ import {
   validateListSliceStartEnd,
 } from '@gomomento/core/dist/src/internal/utils';
 import {normalizeSdkError} from '@gomomento/core/dist/src/errors';
-import {TextEncoder} from 'util';
 
 export interface DataClientProps {
   configuration: Configuration;


### PR DESCRIPTION
browsers don't have access to `utils` to import `TextEncoder`. Inside the browser, `TextEncoder` and `TextDecoder` are globally available, so just removing the import should fix the current issue I am facing

```
Uncaught TypeError: util_1.TextEncoder is not a constructor
```