### PR TITLE
fix: add optional arg for validForSeconds

### DIFF
--- a/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
+++ b/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
@@ -13,7 +13,8 @@ export abstract class AbstractAuthClient implements IAuthClient {
   }
 
   public async generateApiToken(
-    sessionToken: string
+    sessionToken: string,
+    validUntilSeconds?: number
   ): Promise<GenerateApiToken.Response> {
     return await this.authClient.generateApiToken(sessionToken);
   }

--- a/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
+++ b/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
@@ -16,6 +16,9 @@ export abstract class AbstractAuthClient implements IAuthClient {
     sessionToken: string,
     validUntilSeconds?: number
   ): Promise<GenerateApiToken.Response> {
-    return await this.authClient.generateApiToken(sessionToken);
+    return await this.authClient.generateApiToken(
+      sessionToken,
+      validUntilSeconds
+    );
   }
 }

--- a/packages/core/src/internal/clients/auth/IAuthClient.ts
+++ b/packages/core/src/internal/clients/auth/IAuthClient.ts
@@ -1,5 +1,8 @@
 import {GenerateApiToken} from '../../../index';
 
 export interface IAuthClient {
-  generateApiToken(sessionToken: string): Promise<GenerateApiToken.Response>;
+  generateApiToken(
+    sessionToken: string,
+    validUntilSeconds?: number
+  ): Promise<GenerateApiToken.Response>;
 }


### PR DESCRIPTION
this pr plumbs through the optional `validForSeconds` args from the abstract auth client, down to the web/nodejs sdks