### PR TITLE
fix: remove release footgun

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -3,8 +3,6 @@ name: On push to release branch
 on:
   push:
     branches: [release]
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
This change prevents developers from manually triggering a new release from the release branch