### PR TITLE
fix: package-lock.json invalid when installing core dependency for publishing

### DIFF
--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -40,8 +40,13 @@ pushd ${ROOT_DIR}/packages/${PACKAGE}
     # We need to update the version number of the package itself; Also, if it has a dependency on @gomomento/core, then
     # we need to update that dependency version too.
     cat package.json.ORIG | \
-      jq ". += {\"version\": \"${VERSION}\"} | if .dependencies.\"@gomomento/core\"? then .dependencies.\"@gomomento/core\"=\"${CORE_VERSION}\" else . end" \
+      jq ". += {\"version\": \"${VERSION}\"}" \
       > package.json
+    has_dependency_on_core=$(cat package.json|jq '.dependencies."@gomomento/core" != null')
+    if [ "${has_dependency_on_core}" == "true" ];
+    then
+       npm install @gomomento/core@${CORE_VERSION}
+    fi
     echo ""
     echo "New package.json:"
     cat package.json


### PR DESCRIPTION
Prior to this commit the package-lock.json file for the SDK projects
is hard-coded to the 0.0.1 version of core; we then modify the package.json
file to depend on the new version, but attempt an `npm ci` without
updating the package-lock.json first.  In this commit we tweak the
publish logic to do an `npm install` on the appropriate version of
core before we do the `npm ci`.  This should cause the package-lock.json
file to get updated correctly prior to publishing.
