### PR TITLE
fix: uninstall relative sdk-core package before installing released version

### DIFF
--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -45,7 +45,8 @@ pushd ${ROOT_DIR}/packages/${PACKAGE}
     has_dependency_on_core=$(cat package.json|jq '.dependencies."@gomomento/sdk-core" != null')
     if [ "${has_dependency_on_core}" == "true" ];
     then
-       npm install @gomomento/sdk-core@${CORE_VERSION}
+      npm uninstall @gomomento/sdk-core
+      npm install -E @gomomento/sdk-core@${CORE_VERSION}
     fi
     echo ""
     echo "New package.json:"


### PR DESCRIPTION
npm seems to get confused if you try to run `npm install` on a
package that you already have a local relative reference to,
so in this commit we remove the sdk-core dep before attempting
install the new released version of it during a publish.
