### PR TITLE
fix: common-integration-tests needs to use the released sdk-core during publish

### DIFF
--- a/scripts/publish-all-packages.sh
+++ b/scripts/publish-all-packages.sh
@@ -22,7 +22,7 @@ echo "publishing all packages"
 
 ${ROOT_DIR}/scripts/publish-package.sh "core" "${CORE_VERSION}" "${CORE_VERSION}"
 ${ROOT_DIR}/scripts/wait-for-npmjs-release.sh "@gomomento/sdk-core" "${VERSION}"
-${ROOT_DIR}/scripts/build-package.sh "common-integration-tests"
+${ROOT_DIR}/scripts/update-package-versions.sh "common-integration-tests" "${VERSION}" "${CORE_VERSION}"
 ${ROOT_DIR}/scripts/publish-package.sh "client-sdk-nodejs" "${VERSION}" "${CORE_VERSION}"
 
 # We plan to version the web SDK along with the node.js SDK and core library for the time

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -33,29 +33,10 @@ then
    exit 1
 fi
 
+${ROOT_DIR}/scripts/update-package-versions.sh ${PACKAGE} ${VERSION} ${CORE_VERSION}
+
 echo "publishing package: ${PACKAGE} with version ${VERSION} (core version: ${CORE_VERSION})"
 
 pushd ${ROOT_DIR}/packages/${PACKAGE}
-    mv package.json package.json.ORIG
-    # We need to update the version number of the package itself; Also, if it has a dependency on @gomomento/sdk-core, then
-    # we need to update that dependency version too.
-    cat package.json.ORIG | \
-      jq ". += {\"version\": \"${VERSION}\"}" \
-      > package.json
-    has_dependency_on_core=$(cat package.json|jq '.dependencies."@gomomento/sdk-core" != null')
-    if [ "${has_dependency_on_core}" == "true" ];
-    then
-      npm uninstall @gomomento/sdk-core
-      npm install -E @gomomento/sdk-core@${CORE_VERSION}
-    fi
-    echo ""
-    echo "New package.json:"
-    cat package.json
-    echo ""
-    npm ci
-    npm run build
-    npm run lint
-    npm run test
-
     npm publish --access public
 popd

--- a/scripts/update-package-versions.sh
+++ b/scripts/update-package-versions.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -x
+set -e
+
+usage() {
+   echo "Usage: $0 <PACKAGE> <VERSION> <CORE_VERSION>"
+}
+
+ROOT_DIR="$(dirname "$0")/.."
+
+PACKAGE=${1}
+if [ "${PACKAGE}" == "" ]
+then
+   echo "Missing required argument: PACKAGE"
+   usage
+   exit 1
+fi
+
+VERSION=${2}
+if [ "${VERSION}" == "" ]
+then
+   echo "Missing required argument: VERSION"
+   usage
+   exit 1
+fi
+
+CORE_VERSION=${3}
+if [ "${CORE_VERSION}" == "" ]
+then
+   echo "Missing required argument: CORE_VERSION"
+   usage
+   exit 1
+fi
+
+echo "updating package versions: ${PACKAGE} with version ${VERSION} (core version: ${CORE_VERSION})"
+
+pushd ${ROOT_DIR}/packages/${PACKAGE}
+    mv package.json package.json.ORIG
+    # We need to update the version number of the package itself; Also, if it has a dependency on @gomomento/sdk-core, then
+    # we need to update that dependency version too.
+    cat package.json.ORIG | \
+      jq ". += {\"version\": \"${VERSION}\"}" \
+      > package.json
+    has_dependency_on_core=$(cat package.json|jq '.dependencies."@gomomento/sdk-core" != null')
+    if [ "${has_dependency_on_core}" == "true" ];
+    then
+      npm uninstall @gomomento/sdk-core
+      npm install -E @gomomento/sdk-core@${CORE_VERSION}
+    fi
+    echo ""
+    echo "New package.json:"
+    cat package.json
+    echo ""
+    npm ci
+    npm run build
+    npm run lint
+    npm run test
+popd


### PR DESCRIPTION
We get type incompatibilities from version mismatches if the common-integration-tests
package is not built against the released version of sdk-core during the publish
steps.  This commit updates publish so that it bumps dependency versions for the
integration tests package before attempting to build/publish the sdks.
