### PR TITLE
chore: make GenerateApiTokenResponse members private

### DIFF
--- a/packages/core/src/messages/responses/generate-api-token.ts
+++ b/packages/core/src/messages/responses/generate-api-token.ts
@@ -5,10 +5,10 @@ import {encodeToBase64} from '../../internal/utils';
 export abstract class Response extends ResponseBase {}
 
 class _Success extends Response {
-  readonly apiToken: string;
-  readonly refreshToken: string;
-  readonly endpoint: string;
-  readonly validUntil: number;
+  private readonly apiToken: string;
+  private readonly refreshToken: string;
+  private readonly endpoint: string;
+  private readonly validUntil: number;
 
   constructor(
     apiToken: string,


### PR DESCRIPTION
users should only be able to access the members from the response class by using the public getters, rather than accessing the members themselves