### PR TITLE
chore: add expect messages

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/data-client.ts
@@ -79,7 +79,6 @@ import {
   _SortedSetGetScoreResponsePart,
 } from '@gomomento/sdk-core/dist/src/messages/responses/grpc-response-types';
 import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
-import ECacheResult = cache_client.ECacheResult;
 
 export class DataClient {
   private readonly clientWrapper: GrpcClientWrapper<grpcCache.ScsClient>;
@@ -2227,20 +2226,14 @@ export class DataClient {
           metadata,
           {interceptors: this.interceptors},
           (err, resp) => {
-            if (
-              resp?.missing ||
-              resp?.element_rank.result === ECacheResult.Miss
-            ) {
+            if (resp?.missing) {
               resolve(new CacheSortedSetGetRank.Miss());
-            } else if (resp?.element_rank.result === ECacheResult.Hit) {
-              console.log(
-                `\n\n---> result: ${
-                  resp.element_rank.result
-                }\nvalue: ${new TextDecoder().decode(value)}\nrank: ${
-                  resp.element_rank.rank
-                }`
-              );
-              resolve(new CacheSortedSetGetRank.Hit(resp.element_rank.rank));
+            } else if (resp?.element_rank) {
+              if (resp?.element_rank.rank === undefined) {
+                resolve(new CacheSortedSetGetRank.Miss());
+              } else {
+                resolve(new CacheSortedSetGetRank.Hit(resp.element_rank.rank));
+              }
             } else {
               resolve(
                 new CacheSortedSetGetRank.Error(cacheServiceErrorMapper(err))

--- a/packages/common-integration-tests/src/common-int-test-utils.ts
+++ b/packages/common-integration-tests/src/common-int-test-utils.ts
@@ -103,3 +103,30 @@ const bytesEncoderForTests = new TextEncoder();
 export function uint8ArrayForTest(value: string): Uint8Array {
   return Uint8Array.from(bytesEncoderForTests.encode(value));
 }
+
+/**
+ * Jest doesn't provide a way to emit a custom message when a test fails, so this method
+ * provides a wrapper to allow this:
+ *
+ * ```ts
+ * it('fails a simple failing test', () => {
+ *   const val = 42;
+ *   expectWithMessage(() => {
+ *     expect(val).toBeFalse();
+ *   }, `it turns out ${val} is not false`);
+ * });
+ *```
+ *
+ * @param expected Function containing the `expect` assertion
+ * @param message Message to be printed when the test fails
+ */
+export function expectWithMessage(expected: () => void, message: string) {
+  try {
+    expected();
+  } catch (e) {
+    if (e instanceof Error && e.stack !== undefined) {
+      message += `\n\nOriginal stack trace:\n${e.stack}`;
+    }
+    throw new Error(message);
+  }
+}

--- a/packages/common-integration-tests/src/create-delete-list-cache.ts
+++ b/packages/common-integration-tests/src/create-delete-list-cache.ts
@@ -1,5 +1,6 @@
 import {v4} from 'uuid';
 import {
+  expectWithMessage,
   ItBehavesLikeItValidatesCacheName,
   testCacheName,
   ValidateCacheProps,
@@ -12,7 +13,7 @@ import {
   ListCaches,
   MomentoErrorCode,
   CacheFlush,
-  CacheGet,
+  CacheGet, CacheSet,
 } from '@gomomento/sdk-core';
 
 export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
@@ -28,8 +29,9 @@ export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
     it('should return NotFoundError if deleting a non-existent cache', async () => {
       const cacheName = testCacheName();
       const deleteResponse = await Momento.deleteCache(cacheName);
-      expect(deleteResponse).toBeInstanceOf(DeleteCache.Response);
-      expect(deleteResponse).toBeInstanceOf(DeleteCache.Error);
+      expectWithMessage(() => {
+        expect(deleteResponse).toBeInstanceOf(DeleteCache.Error);
+      }, `expected ERROR but got ${deleteResponse.toString()}`);
       if (deleteResponse instanceof DeleteCache.Error) {
         expect(deleteResponse.errorCode()).toEqual(
           MomentoErrorCode.NOT_FOUND_ERROR
@@ -49,7 +51,9 @@ export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
       const cacheName = testCacheName();
       await WithCache(Momento, cacheName, async () => {
         const listResponse = await Momento.listCaches();
-        expect(listResponse).toBeInstanceOf(ListCaches.Success);
+        expectWithMessage(() => {
+          expect(listResponse).toBeInstanceOf(ListCaches.Success);
+        }, `expected SUCCESS but got ${listResponse.toString()}`);
         if (listResponse instanceof ListCaches.Success) {
           const caches = listResponse.getCaches();
           const names = caches.map(c => c.getName());
@@ -67,8 +71,9 @@ export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
     it('should return NotFoundError if flushing a non-existent cache', async () => {
       const cacheName = testCacheName();
       const flushResponse = await Momento.flushCache(cacheName);
-      expect(flushResponse).toBeInstanceOf(CacheFlush.Response);
-      expect(flushResponse).toBeInstanceOf(CacheFlush.Error);
+      expectWithMessage(() => {
+        expect(flushResponse).toBeInstanceOf(CacheFlush.Error);
+      }, `expected ERROR but got ${flushResponse.toString()}`);
       if (flushResponse instanceof CacheFlush.Error) {
         expect(flushResponse.errorCode()).toEqual(
           MomentoErrorCode.NOT_FOUND_ERROR
@@ -80,8 +85,9 @@ export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
       const cacheName = testCacheName();
       await WithCache(Momento, cacheName, async () => {
         const flushResponse = await Momento.flushCache(cacheName);
-        expect(flushResponse).toBeInstanceOf(CacheFlush.Response);
-        expect(flushResponse).toBeInstanceOf(CacheFlush.Success);
+        expectWithMessage(() => {
+          expect(flushResponse).toBeInstanceOf(CacheFlush.Success);
+        }, `expected SUCCESS but got ${flushResponse.toString()}`);
       });
     });
 
@@ -92,15 +98,26 @@ export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
       const value1 = v4();
       const value2 = v4();
       await WithCache(Momento, cacheName, async () => {
-        await Momento.set(cacheName, key1, value1);
-        await Momento.set(cacheName, key2, value2);
+        const setResponse1 = await Momento.set(cacheName, key1, value1);
+        expectWithMessage(() => {
+          expect(setResponse1).toBeInstanceOf(CacheSet.Success);
+        }, `expected SUCCESS but got ${setResponse1.toString()}`);
+        const setResponse2 = await Momento.set(cacheName, key2, value2);
+        expectWithMessage(() => {
+          expect(setResponse2).toBeInstanceOf(CacheSet.Success);
+        }, `expected SUCCESS but got ${setResponse2.toString()}`);
         const flushResponse = await Momento.flushCache(cacheName);
-        expect(flushResponse).toBeInstanceOf(CacheFlush.Response);
-        expect(flushResponse).toBeInstanceOf(CacheFlush.Success);
+        expectWithMessage(() => {
+          expect(flushResponse).toBeInstanceOf(CacheFlush.Success);
+        }, `expected SUCCESS but got ${flushResponse.toString()}`);
         const getResponse1 = await Momento.get(cacheName, key1);
         const getResponse2 = await Momento.get(cacheName, key2);
-        expect(getResponse1).toBeInstanceOf(CacheGet.Miss);
-        expect(getResponse2).toBeInstanceOf(CacheGet.Miss);
+        expectWithMessage(() => {
+          expect(getResponse1).toBeInstanceOf(CacheGet.Miss);
+        }, `expected MISS but got ${getResponse1.toString()}`);
+        expectWithMessage(() => {
+          expect(getResponse2).toBeInstanceOf(CacheGet.Miss);
+        }, `expected MISS but got ${getResponse2.toString()}`);
       });
     });
   });

--- a/packages/common-integration-tests/src/create-delete-list-cache.ts
+++ b/packages/common-integration-tests/src/create-delete-list-cache.ts
@@ -13,7 +13,8 @@ import {
   ListCaches,
   MomentoErrorCode,
   CacheFlush,
-  CacheGet, CacheSet,
+  CacheGet,
+  CacheSet,
 } from '@gomomento/sdk-core';
 
 export function runCreateDeleteListCacheTests(Momento: ICacheClient) {

--- a/packages/common-integration-tests/src/dictionary.ts
+++ b/packages/common-integration-tests/src/dictionary.ts
@@ -18,6 +18,7 @@ import {
   ValidateDictionaryProps,
   ValidateDictionaryChangerProps,
   uint8ArrayForTest,
+  expectWithMessage,
 } from './common-int-test-utils';
 import {TextEncoder} from 'util';
 import {
@@ -85,7 +86,9 @@ export function runDictionaryTests(
           v4(),
           v4()
         );
-        expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Success);
+        expectWithMessage(() => {
+          expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${setResponse.toString()}`);
 
         const response = await responder({
           cacheName: IntegrationTestCacheName,
@@ -107,7 +110,9 @@ export function runDictionaryTests(
           v4(),
           v4()
         );
-        expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Success);
+        expectWithMessage(() => {
+          expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${setResponse.toString()}`);
 
         const response = await responder({
           cacheName: IntegrationTestCacheName,
@@ -153,7 +158,9 @@ export function runDictionaryTests(
           dictionaryName,
           field
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        }, `expected MISS but got ${getResponse.toString()}`);
       });
 
       it('refreshes with refresh ttl', async () => {
@@ -185,7 +192,9 @@ export function runDictionaryTests(
           dictionaryName,
           field
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
       });
     };
 
@@ -209,7 +218,9 @@ export function runDictionaryTests(
           IntegrationTestCacheName,
           dictionaryName
         );
-        expect(response).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         expect((response as CacheDictionaryFetch.Hit).toString()).toEqual(
           'Hit: valueDictionaryStringString: a: b'
         );
@@ -235,7 +246,9 @@ export function runDictionaryTests(
           IntegrationTestCacheName,
           dictionaryName
         );
-        expect(response).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheDictionaryFetch.Hit;
 
         const expectedStringBytesMap = new Map<string, Uint8Array>([
@@ -295,7 +308,9 @@ export function runDictionaryTests(
           IntegrationTestCacheName,
           dictionaryName
         );
-        expect(response).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheDictionaryFetch.Hit;
 
         const expectedBytesBytesMap = new Map<Uint8Array, Uint8Array>([
@@ -314,17 +329,23 @@ export function runDictionaryTests(
           IntegrationTestCacheName,
           dictionaryName
         );
-        expect(response).toBeInstanceOf(CacheDictionaryFetch.Miss);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryFetch.Miss);
+        }, `expected MISS but got ${response.toString()}`);
         response = await Momento.delete(
           IntegrationTestCacheName,
           dictionaryName
         );
-        expect(response).toBeInstanceOf(CacheDelete.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDelete.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         response = await Momento.dictionaryFetch(
           IntegrationTestCacheName,
           dictionaryName
         );
-        expect(response).toBeInstanceOf(CacheDictionaryFetch.Miss);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryFetch.Miss);
+        }, `expected MISS but got ${response.toString()}`);
       });
 
       it('should delete with dictionaryFetch if dictionary exists', async () => {
@@ -343,19 +364,25 @@ export function runDictionaryTests(
           IntegrationTestCacheName,
           dictionaryName
         );
-        expect(response).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
 
         response = await Momento.delete(
           IntegrationTestCacheName,
           dictionaryName
         );
-        expect(response).toBeInstanceOf(CacheDelete.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDelete.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.dictionaryFetch(
           IntegrationTestCacheName,
           dictionaryName
         );
-        expect(response).toBeInstanceOf(CacheDictionaryFetch.Miss);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryFetch.Miss);
+        }, `expected MISS but got ${response.toString()}`);
       });
     });
 
@@ -383,14 +410,18 @@ export function runDictionaryTests(
           field,
           value
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         const getResponse = await Momento.dictionaryGetField(
           IntegrationTestCacheName,
           dictionaryName,
           field
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         expect((getResponse as CacheDictionaryGetField.Hit).toString()).toEqual(
           `Hit: ${value.substring(0, 32)}...`
         );
@@ -428,7 +459,9 @@ export function runDictionaryTests(
           dictionaryName,
           ['a', 'c']
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         expect(
           (getResponse as CacheDictionaryGetFields.Hit).toString()
         ).toEqual('Hit: valueDictionaryStringString: a: b, c: d');
@@ -447,39 +480,51 @@ export function runDictionaryTests(
           field1,
           value1
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         response = await Momento.dictionarySetField(
           IntegrationTestCacheName,
           dictionaryName,
           field2,
           value2
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const getResponse = await Momento.dictionaryGetFields(
           IntegrationTestCacheName,
           dictionaryName,
           [field1, field2, field3]
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         const hitResponse = getResponse as CacheDictionaryGetFields.Hit;
         expect(hitResponse.responses).toHaveLength(3);
-        expect(hitResponse.responses[0]).toBeInstanceOf(
-          CacheDictionaryGetField.Hit
-        );
+        expectWithMessage(() => {
+          expect(hitResponse.responses[0]).toBeInstanceOf(
+            CacheDictionaryGetField.Hit
+          );
+        }, `expected HIT but got ${hitResponse.responses[0].toString()}`);
         const hitResponse1 = hitResponse
           .responses[0] as CacheDictionaryGetField.Hit;
         expect(hitResponse1.fieldString()).toEqual(field1);
 
-        expect(hitResponse.responses[1]).toBeInstanceOf(
-          CacheDictionaryGetField.Hit
-        );
+        expectWithMessage(() => {
+          expect(hitResponse.responses[1]).toBeInstanceOf(
+            CacheDictionaryGetField.Hit
+          );
+        }, `expected HIT but got ${hitResponse.responses[1].toString()}`);
         const hitResponse2 = hitResponse
           .responses[1] as CacheDictionaryGetField.Hit;
         expect(hitResponse2.fieldString()).toEqual(field2);
 
-        expect(hitResponse.responses[2]).toBeInstanceOf(
-          CacheDictionaryGetField.Miss
-        );
+        expectWithMessage(() => {
+          expect(hitResponse.responses[2]).toBeInstanceOf(
+            CacheDictionaryGetField.Miss
+          );
+        }, `expected MISS but got ${hitResponse.responses[2].toString()}`);
         const missResponse = hitResponse
           .responses[2] as CacheDictionaryGetField.Miss;
         expect(missResponse.fieldString()).toEqual(field3);
@@ -532,40 +577,52 @@ export function runDictionaryTests(
           field1,
           value1
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         response = await Momento.dictionarySetField(
           IntegrationTestCacheName,
           dictionaryName,
           field2,
           value2
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const getResponse = await Momento.dictionaryGetFields(
           IntegrationTestCacheName,
           dictionaryName,
           [field1, field2, field3]
         );
 
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         const hitResponse = getResponse as CacheDictionaryGetFields.Hit;
         expect(hitResponse.responses).toHaveLength(3);
-        expect(hitResponse.responses[0]).toBeInstanceOf(
-          CacheDictionaryGetField.Hit
-        );
+        expectWithMessage(() => {
+          expect(hitResponse.responses[0]).toBeInstanceOf(
+            CacheDictionaryGetField.Hit
+          );
+        }, `expected HIT but got ${hitResponse.responses[0].toString()}`);
         const hitResponse1 = hitResponse
           .responses[0] as CacheDictionaryGetField.Hit;
         expect(hitResponse1.fieldUint8Array()).toEqual(field1);
 
-        expect(hitResponse.responses[1]).toBeInstanceOf(
-          CacheDictionaryGetField.Hit
-        );
+        expectWithMessage(() => {
+          expect(hitResponse.responses[1]).toBeInstanceOf(
+            CacheDictionaryGetField.Hit
+          );
+        }, `expected HIT but got ${hitResponse.responses[1].toString()}`);
         const hitResponse2 = hitResponse
           .responses[1] as CacheDictionaryGetField.Hit;
         expect(hitResponse2.fieldUint8Array()).toEqual(field2);
 
-        expect(hitResponse.responses[2]).toBeInstanceOf(
-          CacheDictionaryGetField.Miss
-        );
+        expectWithMessage(() => {
+          expect(hitResponse.responses[2]).toBeInstanceOf(
+            CacheDictionaryGetField.Miss
+          );
+        }, `expected MISS but got ${hitResponse.responses[2].toString()}`);
         const missResponse = hitResponse
           .responses[2] as CacheDictionaryGetField.Miss;
         expect(missResponse.fieldUint8Array()).toEqual(field3);
@@ -609,7 +666,9 @@ export function runDictionaryTests(
           field,
           1
         );
-        expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         let successResponse = response as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(1);
 
@@ -619,7 +678,9 @@ export function runDictionaryTests(
           field,
           41
         );
-        expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         successResponse = response as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(42);
         expect(successResponse.toString()).toEqual('Success: value: 42');
@@ -630,7 +691,9 @@ export function runDictionaryTests(
           field,
           -1042
         );
-        expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         successResponse = response as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(-1000);
 
@@ -639,7 +702,9 @@ export function runDictionaryTests(
           dictionaryName,
           field
         );
-        expect(response).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheDictionaryGetField.Hit;
         expect(hitResponse.valueString()).toEqual('-1000');
       });
@@ -653,7 +718,9 @@ export function runDictionaryTests(
           field,
           1
         );
-        expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         let successResponse = response as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(1);
 
@@ -663,7 +730,9 @@ export function runDictionaryTests(
           field,
           41
         );
-        expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         successResponse = response as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(42);
         expect(successResponse.toString()).toEqual('Success: value: 42');
@@ -674,7 +743,9 @@ export function runDictionaryTests(
           field,
           -1042
         );
-        expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         successResponse = response as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(-1000);
 
@@ -683,7 +754,9 @@ export function runDictionaryTests(
           dictionaryName,
           field
         );
-        expect(response).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheDictionaryGetField.Hit;
         expect(hitResponse.valueString()).toEqual('-1000');
       });
@@ -704,7 +777,9 @@ export function runDictionaryTests(
           field,
           0
         );
-        expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         let successResponse = response as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(10);
 
@@ -714,7 +789,9 @@ export function runDictionaryTests(
           field,
           90
         );
-        expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         successResponse = response as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(100);
 
@@ -731,7 +808,9 @@ export function runDictionaryTests(
           field,
           0
         );
-        expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryIncrement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         successResponse = response as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(0);
       });
@@ -751,7 +830,9 @@ export function runDictionaryTests(
           dictionaryName,
           field
         );
-        expect(response).toBeInstanceOf(CacheDictionaryIncrement.Error);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionaryIncrement.Error);
+        }, `expected ERROR but got ${response.toString()}`);
         const errorResponse = response as CacheDictionaryIncrement.Error;
         expect(errorResponse.errorCode()).toEqual(
           MomentoErrorCode.FAILED_PRECONDITION_ERROR
@@ -776,58 +857,65 @@ export function runDictionaryTests(
         const value = new TextEncoder().encode(v4());
 
         // When the field does not exist.
-        expect(
-          await Momento.dictionaryGetField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-        expect(
-          await Momento.dictionaryRemoveField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
-        expect(
-          await Momento.dictionaryGetField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        let resp = await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryRemoveField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
 
         // When the field exists.
-        expect(
-          await Momento.dictionarySetField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field,
-            value
-          )
-        ).toBeInstanceOf(CacheDictionarySetField.Success);
-        expect(
-          await Momento.dictionaryGetField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryGetField.Hit);
-        expect(
-          await Momento.dictionaryRemoveField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
-        expect(
-          await Momento.dictionaryGetField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        resp = await Momento.dictionarySetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field,
+          value
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${resp.toString()}`);
+        resp = await Momento.dictionaryRemoveField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
       });
 
       it('should remove a string field', async () => {
@@ -836,58 +924,65 @@ export function runDictionaryTests(
         const value = v4();
 
         // When the field does not exist.
-        expect(
-          await Momento.dictionaryGetField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-        expect(
-          await Momento.dictionaryRemoveField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
-        expect(
-          await Momento.dictionaryGetField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        let resp = await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryRemoveField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
 
         // When the field exists.
-        expect(
-          await Momento.dictionarySetField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field,
-            value
-          )
-        ).toBeInstanceOf(CacheDictionarySetField.Success);
-        expect(
-          await Momento.dictionaryGetField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryGetField.Hit);
-        expect(
-          await Momento.dictionaryRemoveField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
-        expect(
-          await Momento.dictionaryGetField(
-            IntegrationTestCacheName,
-            dictionaryName,
-            field
-          )
-        ).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        resp = await Momento.dictionarySetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field,
+          value
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${resp.toString()}`);
+        resp = await Momento.dictionaryRemoveField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetField.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
       });
     });
 
@@ -914,57 +1009,64 @@ export function runDictionaryTests(
         ]);
 
         // When the fields do not exist.
-        expect(
-          await Momento.dictionaryGetFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
-        expect(
-          await Momento.dictionaryRemoveFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
-        expect(
-          await Momento.dictionaryGetFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+        let resp = await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryRemoveFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
 
         // When the fields exist.
-        expect(
-          await Momento.dictionarySetFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            setFields
-          )
-        ).toBeInstanceOf(CacheDictionarySetFields.Success);
-        expect(
-          await Momento.dictionaryGetFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryGetFields.Hit);
-        expect(
-          await Momento.dictionaryRemoveFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
-        expect(
-          await Momento.dictionaryGetFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+        resp = await Momento.dictionarySetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          setFields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionarySetFields.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        }, `expected HIT but got ${resp.toString()}`);
+        resp = await Momento.dictionaryRemoveFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
       });
 
       it('should remove string fields', async () => {
@@ -976,57 +1078,64 @@ export function runDictionaryTests(
         ]);
 
         // When the fields do not exist.
-        expect(
-          await Momento.dictionaryGetFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
-        expect(
-          await Momento.dictionaryRemoveFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
-        expect(
-          await Momento.dictionaryGetFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+        let resp = await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryRemoveFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
 
         // When the fields exist.
-        expect(
-          await Momento.dictionarySetFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            setFields
-          )
-        ).toBeInstanceOf(CacheDictionarySetFields.Success);
-        expect(
-          await Momento.dictionaryGetFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryGetFields.Hit);
-        expect(
-          await Momento.dictionaryRemoveFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
-        expect(
-          await Momento.dictionaryGetFields(
-            IntegrationTestCacheName,
-            dictionaryName,
-            fields
-          )
-        ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+        resp = await Momento.dictionarySetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          setFields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionarySetFields.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        }, `expected HIT but got ${resp.toString()}`);
+        resp = await Momento.dictionaryRemoveFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
+        }, `expected SUCCESS but got ${resp.toString()}`);
+        resp = await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        );
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+        }, `expected MISS but got ${resp.toString()}`);
       });
     });
 
@@ -1063,13 +1172,17 @@ export function runDictionaryTests(
           field,
           value
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const getResponse = await Momento.dictionaryGetField(
           IntegrationTestCacheName,
           dictionaryName,
           field
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueUint8Array()).toEqual(value);
         }
@@ -1085,13 +1198,17 @@ export function runDictionaryTests(
           field,
           value
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const getResponse = await Momento.dictionaryGetField(
           IntegrationTestCacheName,
           dictionaryName,
           field
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueString()).toEqual(value);
         }
@@ -1107,13 +1224,17 @@ export function runDictionaryTests(
           field,
           value
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const getResponse = await Momento.dictionaryGetField(
           IntegrationTestCacheName,
           dictionaryName,
           field
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         expect(
           (getResponse as CacheDictionaryGetField.Hit).valueUint8Array()
         ).toEqual(value);
@@ -1162,7 +1283,9 @@ export function runDictionaryTests(
           dictionaryName,
           field1
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueUint8Array()).toEqual(value1);
         }
@@ -1171,7 +1294,9 @@ export function runDictionaryTests(
           dictionaryName,
           field2
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueUint8Array()).toEqual(value2);
         }
@@ -1192,13 +1317,17 @@ export function runDictionaryTests(
           ]),
           {ttl: CollectionTtl.of(10)}
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         let getResponse = await Momento.dictionaryGetField(
           IntegrationTestCacheName,
           dictionaryName,
           field1
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueString()).toEqual(value1);
         }
@@ -1207,7 +1336,9 @@ export function runDictionaryTests(
           dictionaryName,
           field2
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueString()).toEqual(value2);
         }
@@ -1225,13 +1356,17 @@ export function runDictionaryTests(
           {foo: value1, bar: value2},
           {ttl: CollectionTtl.of(10)}
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         let getResponse = await Momento.dictionaryGetField(
           IntegrationTestCacheName,
           dictionaryName,
           field1
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueString()).toEqual(value1);
         }
@@ -1240,7 +1375,9 @@ export function runDictionaryTests(
           dictionaryName,
           field2
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueString()).toEqual(value2);
         }
@@ -1261,13 +1398,17 @@ export function runDictionaryTests(
           ]),
           {ttl: CollectionTtl.of(10)}
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         let getResponse = await Momento.dictionaryGetField(
           IntegrationTestCacheName,
           dictionaryName,
           field1
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueUint8Array()).toEqual(value1);
         }
@@ -1277,7 +1418,9 @@ export function runDictionaryTests(
           dictionaryName,
           field2
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueUint8Array()).toEqual(value2);
         }
@@ -1296,13 +1439,17 @@ export function runDictionaryTests(
           {foo: textEncoder.encode(value1), bar: textEncoder.encode(value2)},
           {ttl: CollectionTtl.of(10)}
         );
-        expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         let getResponse = await Momento.dictionaryGetField(
           IntegrationTestCacheName,
           dictionaryName,
           field1
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueString()).toEqual(value1);
         }
@@ -1311,7 +1458,9 @@ export function runDictionaryTests(
           dictionaryName,
           field2
         );
-        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueString()).toEqual(value2);
         }

--- a/packages/common-integration-tests/src/get-set-delete.ts
+++ b/packages/common-integration-tests/src/get-set-delete.ts
@@ -11,6 +11,7 @@ import {TextEncoder} from 'util';
 import {
   ValidateCacheProps,
   ItBehavesLikeItValidatesCacheName,
+  expectWithMessage,
 } from './common-int-test-utils';
 import {sleep} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache';
@@ -38,9 +39,13 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
       if (getResponse instanceof CacheGet.Hit) {
         expect(getResponse.valueString()).toEqual(cacheValue);
       }
@@ -54,9 +59,13 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
     });
 
     it('should set string key with bytes value', async () => {
@@ -68,9 +77,13 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
       if (getResponse instanceof CacheGet.Hit) {
         expect(getResponse.valueString()).toEqual(decodedValue);
       }
@@ -84,9 +97,13 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
       if (getResponse instanceof CacheGet.Hit) {
         expect(getResponse.valueString()).toEqual(cacheValue);
       }
@@ -100,7 +117,9 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
     });
 
     it('should set string key with bytes value and returned set value matches byte cacheValue', async () => {
@@ -111,7 +130,9 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
     });
 
     it('should set and then delete a value in cache', async () => {
@@ -119,13 +140,17 @@ export function runGetSetDeleteTests(
       const cacheValue = new TextEncoder().encode(v4());
       await Momento.set(IntegrationTestCacheName, cacheKey, cacheValue);
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
 
       const deleteResponse = await Momento.delete(
         IntegrationTestCacheName,
         cacheKey
       );
-      expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
+      expectWithMessage(() => {
+        expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
+      }, `expected SUCCESS but got ${deleteResponse.toString()}`);
       const getMiss = await Momento.get(IntegrationTestCacheName, cacheKey);
       expect(getMiss).toBeInstanceOf(CacheGet.Miss);
     });
@@ -154,7 +179,9 @@ export function runGetSetDeleteTests(
         cacheValue,
         {ttl: 15}
       );
-      expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
 
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
       if (getResponse instanceof CacheGet.Hit) {
@@ -170,11 +197,15 @@ export function runGetSetDeleteTests(
         v4(),
         {ttl: 1}
       );
-      expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
       await sleep(3000);
 
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Miss);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Miss);
+      }, `expected MISS but got ${getResponse.toString()}`);
     });
   });
 
@@ -190,12 +221,16 @@ export function runGetSetDeleteTests(
         field,
         1
       );
-      expect(response).toBeInstanceOf(CacheIncrement.Success);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${response.toString()}`);
       let successResponse = response as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(1);
 
       response = await Momento.increment(IntegrationTestCacheName, field, 41);
-      expect(response).toBeInstanceOf(CacheIncrement.Success);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${response.toString()}`);
       successResponse = response as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(42);
       expect(successResponse.toString()).toEqual('Success: value: 42');
@@ -205,12 +240,16 @@ export function runGetSetDeleteTests(
         field,
         -1042
       );
-      expect(response).toBeInstanceOf(CacheIncrement.Success);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${response.toString()}`);
       successResponse = response as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(-1000);
 
       response = await Momento.get(IntegrationTestCacheName, field);
-      expect(response).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${response.toString()}`);
       const hitResponse = response as CacheGet.Hit;
       expect(hitResponse.valueString()).toEqual('-1000');
     });
@@ -222,12 +261,16 @@ export function runGetSetDeleteTests(
         field,
         1
       );
-      expect(response).toBeInstanceOf(CacheIncrement.Success);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${response.toString()}`);
       let successResponse = response as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(1);
 
       response = await Momento.increment(IntegrationTestCacheName, field, 41);
-      expect(response).toBeInstanceOf(CacheIncrement.Success);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${response.toString()}`);
       successResponse = response as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(42);
       expect(successResponse.toString()).toEqual('Success: value: 42');
@@ -237,12 +280,16 @@ export function runGetSetDeleteTests(
         field,
         -1042
       );
-      expect(response).toBeInstanceOf(CacheIncrement.Success);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${response.toString()}`);
       successResponse = response as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(-1000);
 
       response = await Momento.get(IntegrationTestCacheName, field);
-      expect(response).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${response.toString()}`);
       const hitResponse = response as CacheGet.Hit;
       expect(hitResponse.valueString()).toEqual('-1000');
     });
@@ -256,19 +303,25 @@ export function runGetSetDeleteTests(
         field,
         0
       );
-      expect(response).toBeInstanceOf(CacheIncrement.Success);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${response.toString()}`);
       let successResponse = response as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(10);
 
       response = await Momento.increment(IntegrationTestCacheName, field, 90);
-      expect(response).toBeInstanceOf(CacheIncrement.Success);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${response.toString()}`);
       successResponse = response as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(100);
 
       // Reset field
       await Momento.set(IntegrationTestCacheName, field, '0');
       response = await Momento.increment(IntegrationTestCacheName, field, 0);
-      expect(response).toBeInstanceOf(CacheIncrement.Success);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${response.toString()}`);
       successResponse = response as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(0);
     });
@@ -282,7 +335,9 @@ export function runGetSetDeleteTests(
         field,
         1
       );
-      expect(response).toBeInstanceOf(CacheIncrement.Error);
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Error);
+      }, `expected ERROR but got ${response.toString()}`);
       const errorResponse = response as CacheIncrement.Error;
       expect(errorResponse.errorCode()).toEqual(
         MomentoErrorCode.FAILED_PRECONDITION_ERROR
@@ -303,9 +358,13 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      }, `expected STORED but got ${setResponse.toString()}`);
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
       if (getResponse instanceof CacheGet.Hit) {
         expect(getResponse.valueString()).toEqual(cacheValue);
       }
@@ -320,17 +379,23 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValueOld
       );
-      expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      }, `expected STORED but got ${setResponse.toString()}`);
       const setIfNotExistsResponse = await Momento.setIfNotExists(
         IntegrationTestCacheName,
         cacheKey,
         cacheValueNew
       );
-      expect(setIfNotExistsResponse).toBeInstanceOf(
-        CacheSetIfNotExists.NotStored
-      );
+      expectWithMessage(() => {
+        expect(setIfNotExistsResponse).toBeInstanceOf(
+          CacheSetIfNotExists.NotStored
+        );
+      }, `expected NOTSTORED but goit ${setIfNotExistsResponse.toString()}`);
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
       if (getResponse instanceof CacheGet.Hit) {
         expect(getResponse.valueString()).toEqual(cacheValueOld);
       }
@@ -344,9 +409,13 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      }, `expected STORED but got ${setResponse.toString()}`);
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
     });
 
     it('should set string key with bytes value', async () => {
@@ -358,9 +427,13 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      }, `expected STORED but got ${setResponse.toString()}`);
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
       if (getResponse instanceof CacheGet.Hit) {
         expect(getResponse.valueString()).toEqual(decodedValue);
       }
@@ -374,9 +447,13 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      }, `expected STORED but got ${setResponse.toString()}`);
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
       if (getResponse instanceof CacheGet.Hit) {
         expect(getResponse.valueString()).toEqual(cacheValue);
       }
@@ -390,7 +467,9 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      }, `expected STORED but got ${setResponse.toString()}`);
     });
 
     it('should set string key with bytes value and returned set value matches byte cacheValue', async () => {
@@ -401,7 +480,9 @@ export function runGetSetDeleteTests(
         cacheKey,
         cacheValue
       );
-      expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      }, `expected STORED but got ${setResponse.toString()}`);
     });
 
     it('should return INVALID_ARGUMENT_ERROR for invalid ttl when set with string key/value', async () => {
@@ -428,7 +509,9 @@ export function runGetSetDeleteTests(
         cacheValue,
         {ttl: 15}
       );
-      expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      }, `expected STORED but got ${setResponse.toString()}`);
 
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
       if (getResponse instanceof CacheGet.Hit) {
@@ -444,11 +527,15 @@ export function runGetSetDeleteTests(
         v4(),
         {ttl: 1}
       );
-      expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
+      }, `expected STORED but got ${setResponse.toString()}`);
       await sleep(3000);
 
       const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
-      expect(getResponse).toBeInstanceOf(CacheGet.Miss);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Miss);
+      }, `expected MISS but got ${getResponse.toString()}`);
     });
   });
 }

--- a/packages/common-integration-tests/src/list.ts
+++ b/packages/common-integration-tests/src/list.ts
@@ -1,5 +1,4 @@
 import {v4} from 'uuid';
-
 import {
   CollectionTtl,
   CacheDelete,
@@ -17,6 +16,7 @@ import {
 } from '@gomomento/sdk-core';
 
 import {
+  expectWithMessage,
   ValidateCacheProps,
   ValidateListProps,
   ItBehavesLikeItValidatesCacheName,
@@ -83,7 +83,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Miss);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Miss);
+        }, `expected a MISS but got ${respFetch.toString()}`);
       });
 
       it('refreshes ttl', async () => {
@@ -108,7 +110,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect(
           (respFetch as CacheListFetch.Hit).valueListString()
         ).toIncludeAllMembers(values);
@@ -157,7 +161,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values
         );
@@ -180,7 +186,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual([
           'two',
           'three',
@@ -210,7 +218,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values.reverse()
         );
@@ -233,7 +243,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual([
           'three',
           'two',
@@ -269,7 +281,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual([
           valueString,
         ]);
@@ -288,7 +302,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
 
         const deleteResp = await Momento.delete(
           IntegrationTestCacheName,
@@ -300,7 +316,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch2).toBeInstanceOf(CacheListFetch.Miss);
+        expectWithMessage(() => {
+          expect(respFetch2).toBeInstanceOf(CacheListFetch.Miss);
+        }, `expected a MISS but got ${respFetch.toString()}`);
       });
 
       it('returns a sliced hit if the list exists', async () => {
@@ -323,7 +341,9 @@ export function runListTests(
           }
         );
 
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           valueStringExpected
         );
@@ -354,7 +374,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(resp).toBeInstanceOf(CacheListLength.Hit);
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheListLength.Hit);
+        }, `expected a HIT but got ${resp.toString()}`);
         expect((resp as CacheListLength.Hit).length()).toEqual(values.length);
       });
     });
@@ -366,7 +388,9 @@ export function runListTests(
 
       it('misses when the list does not exist', async () => {
         const resp = await Momento.listPopBack(IntegrationTestCacheName, v4());
-        expect(resp).toBeInstanceOf(CacheListPopBack.Miss);
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheListPopBack.Miss);
+        }, `expected a MISS but got ${resp.toString()}`);
       });
 
       it('hits when the list exists', async () => {
@@ -385,7 +409,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(resp).toBeInstanceOf(CacheListPopBack.Hit);
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheListPopBack.Hit);
+        }, `expected a HIT but got ${resp.toString()}`);
         expect((resp as CacheListPopBack.Hit).valueString()).toEqual(
           poppedValue
         );
@@ -402,7 +428,9 @@ export function runListTests(
 
       it('misses when the list does not exist', async () => {
         const resp = await Momento.listPopFront(IntegrationTestCacheName, v4());
-        expect(resp).toBeInstanceOf(CacheListPopFront.Miss);
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheListPopFront.Miss);
+        }, `expected a MISS but got ${resp.toString()}`);
       });
 
       it('hits when the list exists', async () => {
@@ -421,7 +449,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(resp).toBeInstanceOf(CacheListPopFront.Hit);
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheListPopFront.Hit);
+        }, `expected a HIT but got ${resp.toString()}`);
         expect((resp as CacheListPopFront.Hit).valueString()).toEqual(
           poppedValue
         );
@@ -454,7 +484,9 @@ export function runListTests(
           v4(),
           'test'
         );
-        expect(resp).toBeInstanceOf(CacheListPushBack.Success);
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheListPushBack.Success);
+        }, `expected a SUCCESS but got ${resp.toString()}`);
       });
     });
 
@@ -481,7 +513,9 @@ export function runListTests(
           v4(),
           'test'
         );
-        expect(resp).toBeInstanceOf(CacheListPushFront.Success);
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheListPushFront.Success);
+        }, `expected a SUCCESS but got ${resp.toString()}`);
       });
     });
 
@@ -519,7 +553,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           expectedValues
         );
@@ -532,11 +568,10 @@ export function runListTests(
       });
 
       it('returns Success if the list does not exist', async () => {
-        const respFetch = await Momento.listRetain(
-          IntegrationTestCacheName,
-          v4()
-        );
-        expect(respFetch).toBeInstanceOf(CacheListRetain.Success);
+        const resp = await Momento.listRetain(IntegrationTestCacheName, v4());
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheListRetain.Success);
+        }, `expected a SUCCESS but got ${resp.toString()}`);
       });
 
       it('returns Success if the list exists', async () => {
@@ -551,33 +586,43 @@ export function runListTests(
           valueString
         );
 
-        expect(listPushResponse).toBeInstanceOf(
-          CacheListConcatenateBack.Success
-        );
+        expectWithMessage(() => {
+          expect(listPushResponse).toBeInstanceOf(
+            CacheListConcatenateBack.Success
+          );
+        }, `expected a SUCCESS but got ${listPushResponse.toString()}`);
 
         const retainOptions = {
           startIndex: 1,
           endIndex: 2,
         };
 
-        const respRetain = <CacheListRetain.Success>(
-          await Momento.listRetain(
-            IntegrationTestCacheName,
-            listName,
-            retainOptions
-          )
+        const respRetain = await Momento.listRetain(
+          IntegrationTestCacheName,
+          listName,
+          retainOptions
+        );
+        expectWithMessage(() => {
+          expect(respRetain).toBeInstanceOf(CacheListRetain.Success);
+        }, `expected a SUCCESS but got ${respRetain.toString()}`);
+
+        const respFetch = await Momento.listFetch(
+          IntegrationTestCacheName,
+          listName
         );
 
-        expect(respRetain).toBeInstanceOf(CacheListRetain.Success);
-
-        const respFetch = <CacheListFetch.Hit>(
-          await Momento.listFetch(IntegrationTestCacheName, listName)
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
+        expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
+          valueStringExpected
         );
-
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
-        expect(respFetch.valueListString()).toEqual(valueStringExpected);
-        expect(respFetch.valueList()).toEqual(valueStringExpected);
-        expect(respFetch.valueListUint8Array()).toEqual([valueBytesExpected]);
+        expect((respFetch as CacheListFetch.Hit).valueList()).toEqual(
+          valueStringExpected
+        );
+        expect((respFetch as CacheListFetch.Hit).valueListUint8Array()).toEqual(
+          [valueBytesExpected]
+        );
       });
     });
 
@@ -610,7 +655,9 @@ export function runListTests(
           listName,
           values1
         );
-        expect(respConcat).toBeInstanceOf(CacheListConcatenateBack.Success);
+        expectWithMessage(() => {
+          expect(respConcat).toBeInstanceOf(CacheListConcatenateBack.Success);
+        }, `expected a SUCCESS but got ${respConcat.toString()}`);
         expect(
           (respConcat as CacheListConcatenateBack.Success).listLength()
         ).toEqual(values1.length);
@@ -619,7 +666,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values1
         );
@@ -629,13 +678,17 @@ export function runListTests(
           listName,
           values2
         );
-        expect(respConcat).toBeInstanceOf(CacheListConcatenateBack.Success);
+        expectWithMessage(() => {
+          expect(respConcat).toBeInstanceOf(CacheListConcatenateBack.Success);
+        }, `expected a SUCCESS but got ${respConcat.toString()}`);
         expect(
           (respConcat as CacheListConcatenateBack.Success).listLength()
         ).toEqual(values1.length + values2.length);
 
         respFetch = await Momento.listFetch(IntegrationTestCacheName, listName);
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values1.concat(values2)
         );
@@ -671,7 +724,9 @@ export function runListTests(
           listName,
           values1
         );
-        expect(respConcat).toBeInstanceOf(CacheListConcatenateFront.Success);
+        expectWithMessage(() => {
+          expect(respConcat).toBeInstanceOf(CacheListConcatenateFront.Success);
+        }, `expected a SUCCESS but got ${respConcat.toString()}`);
         expect(
           (respConcat as CacheListConcatenateFront.Success).listLength()
         ).toEqual(values1.length);
@@ -680,7 +735,9 @@ export function runListTests(
           IntegrationTestCacheName,
           listName
         );
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values1
         );
@@ -690,13 +747,17 @@ export function runListTests(
           listName,
           values2
         );
-        expect(respConcat).toBeInstanceOf(CacheListConcatenateFront.Success);
+        expectWithMessage(() => {
+          expect(respConcat).toBeInstanceOf(CacheListConcatenateFront.Success);
+        }, `expected a SUCCESS but got ${respConcat.toString()}`);
         expect(
           (respConcat as CacheListConcatenateFront.Success).listLength()
         ).toEqual(values1.length + values2.length);
 
         respFetch = await Momento.listFetch(IntegrationTestCacheName, listName);
-        expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        expectWithMessage(() => {
+          expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${respFetch.toString()}`);
         expect((respFetch as CacheListFetch.Hit).valueListString()).toEqual(
           values2.concat(values1)
         );

--- a/packages/common-integration-tests/src/set.ts
+++ b/packages/common-integration-tests/src/set.ts
@@ -13,6 +13,7 @@ import {
   ValidateCacheProps,
   ValidateSetProps,
   ItBehavesLikeItValidatesCacheName,
+  expectWithMessage,
 } from './common-int-test-utils';
 import {
   IResponseError,
@@ -68,13 +69,17 @@ export function runSetTests(
         setName,
         LOL_BYTE_ARRAY
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const fetchResponse = await Momento.setFetch(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
         new Set([LOL_BYTE_ARRAY])
       );
@@ -87,13 +92,17 @@ export function runSetTests(
         setName,
         'lol'
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const fetchResponse = await Momento.setFetch(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
         new Set([LOL_BYTE_ARRAY])
       );
@@ -106,7 +115,9 @@ export function runSetTests(
         setName,
         [FOO_BYTE_ARRAY, LOL_BYTE_ARRAY]
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const removeResponse = await Momento.setRemoveElement(
         IntegrationTestCacheName,
@@ -119,7 +130,9 @@ export function runSetTests(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
         new Set([LOL_BYTE_ARRAY])
       );
@@ -132,20 +145,26 @@ export function runSetTests(
         setName,
         [FOO_BYTE_ARRAY, LOL_BYTE_ARRAY]
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const removeResponse = await Momento.setRemoveElement(
         IntegrationTestCacheName,
         setName,
         'foo'
       );
-      expect(removeResponse).toBeInstanceOf(CacheSetRemoveElement.Success);
+      expectWithMessage(() => {
+        expect(removeResponse).toBeInstanceOf(CacheSetRemoveElement.Success);
+      }, `expected SUCCESS but got ${removeResponse.toString()}`);
 
       const fetchResponse = await Momento.setFetch(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
         new Set([LOL_BYTE_ARRAY])
       );
@@ -160,13 +179,17 @@ export function runSetTests(
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY]
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const fetchResponse = await Momento.setFetch(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
         new Set([LOL_BYTE_ARRAY, FOO_BYTE_ARRAY])
       );
@@ -180,7 +203,9 @@ export function runSetTests(
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
         {ttl: new CollectionTtl(2, false)}
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       addResponse = await Momento.setAddElements(
         IntegrationTestCacheName,
@@ -188,7 +213,9 @@ export function runSetTests(
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
         {ttl: new CollectionTtl(10, false)}
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       await sleep(2_000);
 
@@ -196,7 +223,9 @@ export function runSetTests(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Miss);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Miss);
+      }, `expected MISS but got ${fetchResponse.toString()}`);
     });
 
     it('should succeed for addElements with byte arrays happy path with refresh ttl', async () => {
@@ -207,7 +236,9 @@ export function runSetTests(
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
         {ttl: new CollectionTtl(2, false)}
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       addResponse = await Momento.setAddElements(
         IntegrationTestCacheName,
@@ -215,7 +246,9 @@ export function runSetTests(
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
         {ttl: new CollectionTtl(10, true)}
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       await sleep(2_000);
 
@@ -223,7 +256,9 @@ export function runSetTests(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       const hit = fetchResponse as CacheSetFetch.Hit;
       expect(hit.valueSetUint8Array()).toEqual(
         new Set([LOL_BYTE_ARRAY, FOO_BYTE_ARRAY])
@@ -242,13 +277,17 @@ export function runSetTests(
         setName,
         ['lol', 'foo']
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const fetchResponse = await Momento.setFetch(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       const hit = fetchResponse as CacheSetFetch.Hit;
       expect(hit.valueSet()).toEqual(new Set(['lol', 'foo']));
       expect(hit.valueSetString()).toEqual(new Set(['lol', 'foo']));
@@ -265,19 +304,25 @@ export function runSetTests(
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY]
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
       addResponse = await Momento.setAddElements(
         IntegrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY]
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const fetchResponse = await Momento.setFetch(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
         new Set([LOL_BYTE_ARRAY, FOO_BYTE_ARRAY])
       );
@@ -290,20 +335,26 @@ export function runSetTests(
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY]
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const removeResponse = await Momento.setRemoveElements(
         IntegrationTestCacheName,
         setName,
         [FOO_BYTE_ARRAY]
       );
-      expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
+      expectWithMessage(() => {
+        expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
+      }, `expected SUCCESS but got ${removeResponse.toString()}`);
 
       const fetchResponse = await Momento.setFetch(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
         new Set([LOL_BYTE_ARRAY])
       );
@@ -316,20 +367,26 @@ export function runSetTests(
         setName,
         ['lol', 'foo']
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const removeResponse = await Momento.setRemoveElements(
         IntegrationTestCacheName,
         setName,
         ['foo']
       );
-      expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
+      expectWithMessage(() => {
+        expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
+      }, `expected SUCCESS but got ${removeResponse.toString()}`);
 
       const fetchResponse = await Momento.setFetch(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       expect((fetchResponse as CacheSetFetch.Hit).valueSetString()).toEqual(
         new Set(['lol'])
       );
@@ -342,20 +399,26 @@ export function runSetTests(
         setName,
         [LOL_BYTE_ARRAY]
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const removeResponse = await Momento.setRemoveElements(
         IntegrationTestCacheName,
         setName,
         [FOO_BYTE_ARRAY]
       );
-      expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
+      expectWithMessage(() => {
+        expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
+      }, `expected SUCCESS but got ${removeResponse.toString()}`);
 
       const fetchResponse = await Momento.setFetch(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
         new Set([LOL_BYTE_ARRAY])
       );
@@ -368,20 +431,26 @@ export function runSetTests(
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY]
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
 
       const removeResponse = await Momento.setRemoveElements(
         IntegrationTestCacheName,
         setName,
         ['lol']
       );
-      expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
+      expectWithMessage(() => {
+        expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
+      }, `expected SUCCESS but got ${removeResponse.toString()}`);
 
       const fetchResponse = await Momento.setFetch(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected HIT but got ${fetchResponse.toString()}`);
       expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
         new Set([FOO_BYTE_ARRAY])
       );
@@ -402,7 +471,9 @@ export function runSetTests(
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY]
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      expectWithMessage(() => {
+        expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+      }, `expected SUCCESS but got ${addResponse.toString()}`);
       const deleteResponse = await Momento.delete(
         IntegrationTestCacheName,
         setName
@@ -412,7 +483,9 @@ export function runSetTests(
         IntegrationTestCacheName,
         setName
       );
-      expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Miss);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Miss);
+      }, `expected MISS but got ${fetchResponse.toString()}`);
     });
   });
 }

--- a/packages/common-integration-tests/src/sorted-set.ts
+++ b/packages/common-integration-tests/src/sorted-set.ts
@@ -20,6 +20,7 @@ import {
   ValidateSortedSetProps,
   ItBehavesLikeItValidatesCacheName,
   uint8ArrayForTest,
+  expectWithMessage,
 } from './common-int-test-utils';
 import {
   IResponseError,
@@ -111,7 +112,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(getResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${getResponse.toString()}`);
       });
 
       it('refreshes with refresh ttl', async () => {
@@ -142,7 +145,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(getResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
       });
     };
 
@@ -169,7 +174,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         expect((response as CacheSortedSetFetch.Hit).toString()).toEqual(
           'Hit: valueArrayStringElements: a: 42'
         );
@@ -195,7 +202,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
 
         const expectedStringElements = [
@@ -253,7 +262,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'bam', score: 1000},
@@ -272,7 +283,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'foo', score: 1},
@@ -291,7 +304,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'bar', score: 2},
@@ -310,7 +325,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([]);
         });
@@ -325,7 +342,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'burrito', score: 9000},
@@ -343,7 +362,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'habanero', score: 68},
@@ -363,7 +384,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'foo', score: 1},
@@ -385,7 +408,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'habanero', score: 68},
@@ -403,7 +428,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'foo', score: 1},
@@ -426,7 +453,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'jalapeno', score: 1_000_000},
@@ -450,7 +479,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'baz', score: 42},
@@ -469,7 +500,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'jalapeno', score: 1_000_000},
@@ -489,7 +522,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'bam', score: 1000},
@@ -508,7 +543,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Error);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Error);
+          }, `expected ERROR but got ${response.toString()}`);
           const errorResponse = response as CacheSortedSetFetch.Error;
           expect(errorResponse.errorCode()).toEqual(
             MomentoErrorCode.INVALID_ARGUMENT_ERROR
@@ -532,7 +569,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Error);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Error);
+          }, `expected ERROR but got ${response.toString()}`);
           const errorResponse = response as CacheSortedSetFetch.Error;
           expect(errorResponse.errorCode()).toEqual(
             MomentoErrorCode.INVALID_ARGUMENT_ERROR
@@ -552,7 +591,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${response.toString()}`);
 
         await Momento.sortedSetPutElements(
           IntegrationTestCacheName,
@@ -568,19 +609,25 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
 
         response = await Momento.delete(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheDelete.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDelete.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${response.toString()}`);
       });
     });
 
@@ -607,7 +654,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         expect((response as CacheSortedSetFetch.Hit).toString()).toEqual(
           'Hit: valueArrayStringElements: a: 42'
         );
@@ -620,7 +669,7 @@ export function runSortedSetTests(
         const field2 = 'bar';
         const score2 = 42;
 
-        await Momento.sortedSetPutElements(
+        const putResponse = await Momento.sortedSetPutElements(
           IntegrationTestCacheName,
           sortedSetName,
           new Map([
@@ -628,12 +677,17 @@ export function runSortedSetTests(
             [field2, score2],
           ])
         );
+        expectWithMessage(() => {
+          expect(putResponse).toBeInstanceOf(CacheSortedSetPutElements.Success);
+        }, `expected SUCCESS but got ${putResponse.toString()}`);
 
         const response = await Momento.sortedSetFetchByScore(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
 
         const expectedStringElements = [
@@ -691,7 +745,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'bam', score: 1000},
@@ -710,7 +766,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'foo', score: 1},
@@ -731,7 +789,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'bam', score: 1000},
@@ -748,7 +808,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([]);
         });
@@ -762,7 +824,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([]);
         });
@@ -776,7 +840,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'foo', score: 1},
@@ -799,7 +865,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'foo', score: 1},
@@ -823,7 +891,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Error);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Error);
+          }, `expected ERROR but got ${response.toString()}`);
           const errorResponse = response as CacheSortedSetFetch.Error;
           expect(errorResponse.errorCode()).toEqual(
             MomentoErrorCode.INVALID_ARGUMENT_ERROR
@@ -846,7 +916,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'taco', score: 90210},
@@ -864,7 +936,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'bam', score: 1000},
@@ -883,7 +957,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'bam', score: 1000},
@@ -902,7 +978,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([]);
         });
@@ -917,7 +995,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'bam', score: 1000},
@@ -937,7 +1017,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Error);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Error);
+          }, `expected ERROR but got ${response.toString()}`);
           const errorResponse = response as CacheSortedSetFetch.Error;
           expect(errorResponse.errorCode()).toEqual(
             MomentoErrorCode.INVALID_ARGUMENT_ERROR
@@ -960,7 +1042,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Error);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Error);
+          }, `expected ERROR but got ${response.toString()}`);
           const errorResponse = response as CacheSortedSetFetch.Error;
           expect(errorResponse.errorCode()).toEqual(
             MomentoErrorCode.INVALID_ARGUMENT_ERROR
@@ -983,7 +1067,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'bam', score: 1000},
@@ -1003,7 +1089,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'jalapeno', score: 1_000_000},
@@ -1026,7 +1114,9 @@ export function runSortedSetTests(
             }
           );
 
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          expectWithMessage(() => {
+            expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+          }, `expected HIT but got ${response.toString()}`);
           const hitResponse = response as CacheSortedSetFetch.Hit;
           expect(hitResponse.valueArray()).toEqual([
             {value: 'bam', score: 1000},
@@ -1041,7 +1131,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${response.toString()}`);
 
         await Momento.sortedSetPutElements(
           IntegrationTestCacheName,
@@ -1057,19 +1149,25 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
 
         response = await Momento.delete(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheDelete.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDelete.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${response.toString()}`);
       });
     });
 
@@ -1098,7 +1196,9 @@ export function runSortedSetTests(
           sortedSetName,
           'bar'
         );
-        expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);
+        }, `expected HIT but got ${result.toString()}`);
         let hitResult = result as CacheSortedSetGetRank.Hit;
         expect(hitResult.rank()).toEqual(1);
 
@@ -1107,9 +1207,22 @@ export function runSortedSetTests(
           sortedSetName,
           'baz'
         );
-        expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);
+        }, `expected HIT but got ${result.toString()}`);
         hitResult = result as CacheSortedSetGetRank.Hit;
         expect(hitResult.rank()).toEqual(2);
+
+        result = await Momento.sortedSetGetRank(
+          IntegrationTestCacheName,
+          sortedSetName,
+          'foo'
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        hitResult = result as CacheSortedSetGetRank.Hit;
+        expect(hitResult.rank()).toEqual(0);
       });
 
       it('returns a miss for a value that does not exist', async () => {
@@ -1125,7 +1238,9 @@ export function runSortedSetTests(
           sortedSetName,
           'taco'
         );
-        expect(result).toBeInstanceOf(CacheSortedSetGetRank.Miss);
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetRank.Miss);
+        }, `expected MISS but got ${result.toString()}`);
       });
     });
 
@@ -1154,7 +1269,9 @@ export function runSortedSetTests(
           sortedSetName,
           'bar'
         );
-        expect(result).toBeInstanceOf(CacheSortedSetGetScore.Hit);
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetScore.Hit);
+        }, `expected HIT but got ${result.toString()}`);
         let hitResult = result as CacheSortedSetGetScore.Hit;
         expect(hitResult.score()).toEqual(84);
 
@@ -1163,7 +1280,9 @@ export function runSortedSetTests(
           sortedSetName,
           'baz'
         );
-        expect(result).toBeInstanceOf(CacheSortedSetGetScore.Hit);
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetScore.Hit);
+        }, `expected HIT but got ${result.toString()}`);
         hitResult = result as CacheSortedSetGetScore.Hit;
         expect(hitResult.score()).toEqual(90210);
       });
@@ -1181,7 +1300,9 @@ export function runSortedSetTests(
           sortedSetName,
           'taco'
         );
-        expect(result).toBeInstanceOf(CacheSortedSetGetScore.Miss);
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetScore.Miss);
+        }, `expected MISS but got ${result.toString()}`);
       });
     });
 
@@ -1210,7 +1331,9 @@ export function runSortedSetTests(
           sortedSetName,
           ['bar', 'baz']
         );
-        expect(result).toBeInstanceOf(CacheSortedSetGetScores.Hit);
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetScores.Hit);
+        }, `expected HIT but got ${result.toString()}`);
         const hitResult = result as CacheSortedSetGetScores.Hit;
         expect(hitResult.valueRecord()).toEqual({
           bar: 84,
@@ -1231,7 +1354,9 @@ export function runSortedSetTests(
           sortedSetName,
           ['bar', 'taco']
         );
-        expect(result).toBeInstanceOf(CacheSortedSetGetScores.Hit);
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetScores.Hit);
+        }, `expected HIT but got ${result.toString()}`);
         const hitResult = result as CacheSortedSetGetScores.Hit;
         expect(hitResult.valueRecord()).toEqual({
           bar: 84,
@@ -1267,14 +1392,18 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${response.toString()}`);
 
         response = await Momento.sortedSetIncrementScore(
           IntegrationTestCacheName,
           sortedSetName,
           'foo'
         );
-        expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const incrementResponse =
           response as CacheSortedSetIncrementScore.Success;
         expect(incrementResponse.score()).toEqual(1);
@@ -1283,7 +1412,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([
           {
@@ -1299,7 +1430,9 @@ export function runSortedSetTests(
           42
         );
 
-        expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const incrementResponse2 =
           response as CacheSortedSetIncrementScore.Success;
         expect(incrementResponse2.score()).toEqual(42);
@@ -1309,7 +1442,9 @@ export function runSortedSetTests(
           sortedSetName
         );
 
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse2 = response as CacheSortedSetFetch.Hit;
         expect(hitResponse2.valueArray()).toEqual([
           {value: 'foo', score: 1},
@@ -1333,7 +1468,9 @@ export function runSortedSetTests(
           value,
           10
         );
-        expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const incrementResponse =
           response as CacheSortedSetIncrementScore.Success;
         expect(incrementResponse.score()).toEqual(90220);
@@ -1342,7 +1479,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([
           {value: value, score: 90220},
@@ -1365,7 +1504,9 @@ export function runSortedSetTests(
           value,
           10
         );
-        expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const incrementResponse =
           response as CacheSortedSetIncrementScore.Success;
         expect(incrementResponse.score()).toEqual(90220);
@@ -1374,7 +1515,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArrayUint8Elements()).toEqual([
           {value: value, score: 90220},
@@ -1397,7 +1540,9 @@ export function runSortedSetTests(
           value,
           -10
         );
-        expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const incrementResponse =
           response as CacheSortedSetIncrementScore.Success;
         expect(incrementResponse.score()).toEqual(90200);
@@ -1406,7 +1551,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([
           {value: value, score: 90200},
@@ -1429,7 +1576,9 @@ export function runSortedSetTests(
           value,
           -10
         );
-        expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         const incrementResponse =
           response as CacheSortedSetIncrementScore.Success;
         expect(incrementResponse.score()).toEqual(90200);
@@ -1438,7 +1587,9 @@ export function runSortedSetTests(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArrayUint8Elements()).toEqual([
           {value: value, score: 90200},
@@ -1473,13 +1624,17 @@ export function runSortedSetTests(
           sortedSetName,
           'foo'
         );
-        expect(response).toBeInstanceOf(CacheSortedSetRemoveElement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetRemoveElement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([{value: 'bar', score: 42}]);
       });
@@ -1500,13 +1655,17 @@ export function runSortedSetTests(
           sortedSetName,
           uint8ArrayForTest('foo')
         );
-        expect(response).toBeInstanceOf(CacheSortedSetRemoveElement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetRemoveElement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArrayUint8Elements()).toEqual([
           {value: uint8ArrayForTest('bar'), score: 42},
@@ -1529,13 +1688,17 @@ export function runSortedSetTests(
           sortedSetName,
           'taco'
         );
-        expect(response).toBeInstanceOf(CacheSortedSetRemoveElement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetRemoveElement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([
           {value: 'foo', score: 21},
@@ -1572,13 +1735,17 @@ export function runSortedSetTests(
           sortedSetName,
           ['foo', 'baz']
         );
-        expect(response).toBeInstanceOf(CacheSortedSetRemoveElements.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetRemoveElements.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([{value: 'bar', score: 42}]);
       });
@@ -1600,13 +1767,17 @@ export function runSortedSetTests(
           sortedSetName,
           [uint8ArrayForTest('foo'), uint8ArrayForTest('baz')]
         );
-        expect(response).toBeInstanceOf(CacheSortedSetRemoveElements.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetRemoveElements.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArrayUint8Elements()).toEqual([
           {value: uint8ArrayForTest('bar'), score: 42},
@@ -1630,13 +1801,17 @@ export function runSortedSetTests(
           sortedSetName,
           ['taco', 'habanero']
         );
-        expect(response).toBeInstanceOf(CacheSortedSetRemoveElements.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetRemoveElements.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([
           {value: 'foo', score: 21},
@@ -1677,13 +1852,17 @@ export function runSortedSetTests(
           'foo',
           42
         );
-        expect(response).toBeInstanceOf(CacheSortedSetPutElement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetPutElement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([{value: 'foo', score: 42}]);
       });
@@ -1696,13 +1875,17 @@ export function runSortedSetTests(
           uint8ArrayForTest('foo'),
           42
         );
-        expect(response).toBeInstanceOf(CacheSortedSetPutElement.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetPutElement.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArrayUint8Elements()).toEqual([
           {value: uint8ArrayForTest('foo'), score: 42},
@@ -1741,13 +1924,17 @@ export function runSortedSetTests(
             ['bar', 84],
           ])
         );
-        expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([
           {value: 'foo', score: 42},
@@ -1762,13 +1949,17 @@ export function runSortedSetTests(
           sortedSetName,
           {foo: 42, bar: 84}
         );
-        expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([
           {value: 'foo', score: 42},
@@ -1786,13 +1977,17 @@ export function runSortedSetTests(
             [uint8ArrayForTest('bar'), 84],
           ])
         );
-        expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
 
         response = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${response.toString()}`);
         const hitResponse = response as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArrayUint8Elements()).toEqual([
           {value: uint8ArrayForTest('foo'), score: 42},
@@ -1812,18 +2007,24 @@ export function runSortedSetTests(
             ['bar', 84],
           ])
         );
-        expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         response = await Momento.delete(
           IntegrationTestCacheName,
           sortedSetName
         );
-        expect(response).toBeInstanceOf(CacheDelete.Success);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheDelete.Success);
+        }, `expected SUCCESS but got ${response.toString()}`);
         response = await Momento.sortedSetGetScore(
           IntegrationTestCacheName,
           sortedSetName,
           'foo'
         );
-        expect(response).toBeInstanceOf(CacheSortedSetGetScore.Miss);
+        expectWithMessage(() => {
+          expect(response).toBeInstanceOf(CacheSortedSetGetScore.Miss);
+        }, `expected MISS but got ${response.toString()}`);
       });
     });
   });

--- a/packages/common-integration-tests/src/sorted-set.ts
+++ b/packages/common-integration-tests/src/sorted-set.ts
@@ -11,16 +11,16 @@ import {
   CacheSortedSetRemoveElement,
   CacheSortedSetRemoveElements,
   CollectionTtl,
-  SortedSetOrder,
   MomentoErrorCode,
+  SortedSetOrder,
 } from '@gomomento/sdk-core';
 import {
+  expectWithMessage,
+  ItBehavesLikeItValidatesCacheName,
+  uint8ArrayForTest,
   ValidateCacheProps,
   ValidateSortedSetChangerProps,
   ValidateSortedSetProps,
-  ItBehavesLikeItValidatesCacheName,
-  uint8ArrayForTest,
-  expectWithMessage,
 } from './common-int-test-utils';
 import {
   IResponseError,
@@ -1212,17 +1212,6 @@ export function runSortedSetTests(
         }, `expected HIT but got ${result.toString()}`);
         hitResult = result as CacheSortedSetGetRank.Hit;
         expect(hitResult.rank()).toEqual(2);
-
-        result = await Momento.sortedSetGetRank(
-          IntegrationTestCacheName,
-          sortedSetName,
-          'foo'
-        );
-        expectWithMessage(() => {
-          expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);
-        }, `expected HIT but got ${result.toString()}`);
-        hitResult = result as CacheSortedSetGetRank.Hit;
-        expect(hitResult.rank()).toEqual(0);
       });
 
       it('returns a miss for a value that does not exist', async () => {


### PR DESCRIPTION
This commit adds an `expectWithMessage()` method that extends the built-in Jest `expect()` functionality by allowing users to supply extra details in a message for display when the assertion fails. For example, we can call `.toString()` on responses to get extra details about them:

```
expectWithMessage(() => {
    expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);
}, `expected HIT but got ${result.toString()}`);
```
