### PR TITLE
chore: add better test coverage for sortedSetGetRank

### DIFF
--- a/packages/common-integration-tests/src/sorted-set.ts
+++ b/packages/common-integration-tests/src/sorted-set.ts
@@ -1212,6 +1212,17 @@ export function runSortedSetTests(
         }, `expected HIT but got ${result.toString()}`);
         hitResult = result as CacheSortedSetGetRank.Hit;
         expect(hitResult.rank()).toEqual(2);
+
+        result = await Momento.sortedSetGetRank(
+          IntegrationTestCacheName,
+          sortedSetName,
+          'foo'
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        hitResult = result as CacheSortedSetGetRank.Hit;
+        expect(hitResult.rank()).toEqual(0);
       });
 
       it('returns a miss for a value that does not exist', async () => {


### PR DESCRIPTION
An issue with `grpc-js` is causing the `SortedSetGetRank` operation to return `undefined` as the rank value for the topmost (0-th ranked according to sort order) item in the set. All other rank values are fine, and the same behavior is not observed with `grpc-web` and the web sdk.

This commit introduces a test to demonstrate the bug as well as a temporary workaround that detects the combination of a `hit` cache result and an undefined rank value and changes the rank to zero. This will prevent the top-ranked item in a sorted set from being mishandled as a cache miss. This change is intended to be removed when a root cause and remediation are found.