### PR TITLE
fix: remove logger from generate auth token api

### DIFF
--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -1,5 +1,5 @@
 import {auth} from '@gomomento/generated-types-webtext';
-import {MomentoLogger, GenerateAuthToken, RefreshAuthToken} from '..';
+import {GenerateAuthToken, RefreshAuthToken} from '..';
 import {version} from '../../package.json';
 import {Request, UnaryInterceptor, UnaryResponse} from 'grpc-web';
 import {Header, HeaderInterceptorProvider} from './grpc/headers-interceptor';
@@ -14,8 +14,6 @@ export class InternalWebGrpcAuthClient<
   RESP extends UnaryResponse<REQ, RESP>
 > {
   private readonly interceptors: UnaryInterceptor<REQ, RESP>[];
-  private readonly logger: MomentoLogger;
-
   constructor() {
     const headers = [new Header('Agent', `nodejs:${version}`)];
     this.interceptors = [
@@ -44,7 +42,6 @@ export class InternalWebGrpcAuthClient<
         unaryInterceptors: this.interceptors,
       }
     );
-    this.logger.debug("Issuing 'generateApiToken' request");
     return await new Promise<GenerateAuthToken.Response>(resolve => {
       clientAuthWrapper.generateApiToken(request, null, (err, resp) => {
         if (err) {


### PR DESCRIPTION
## PR Description:
Remove logger from generate auth token api:
When calling the "generateAuthToken" api from console, I encountered the following error:
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'debug')
    at InternalWebGrpcAuthClient.generateAuthToken (auth-client.ts:47:17)
    at AuthClient.generateAuthToken (AbstractAuthClient.ts:25:34)
    at generateAuthToken (controlplane-store.ts:114:5)
    at onClickGenerateToken (Tokens.tsx:56:26)
    at onClick (Tokens.tsx:200:30)
    at HTMLUnknownElement.callCallback2 (react-dom.development.js:4164:14)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:4213:16)
    at invokeGuardedCallback (react-dom.development.js:4277:31)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:4291:25)
    at executeDispatch (react-dom.development.js:9041:3)
```
As per the discussion with @ben-kugler , the quickest way to unblock us from this is to remove the logging statement from the sdk. 



