### PR TITLE
feat: rename sessionToken param to token

### DIFF
--- a/packages/client-sdk-nodejs/src/auth-client.ts
+++ b/packages/client-sdk-nodejs/src/auth-client.ts
@@ -19,7 +19,7 @@ export class AuthClient extends AbstractAuthClient implements IAuthClient {
    * Gets a api token, refresh token given a valid session token.
    *
    * @param {string} controlEndpoint - Endpoint for control plane.
-   * @param {string} sessionToken - The session token to allow access for generation of api tokens.
+   * @param {string} token - The token to allow access for generation of api tokens.
    * @param {string} expiresIn - How long the token is valid for in epoch timestamp.
    * @returns {Promise<GenerateAuthToken.Response>} -
    * {@link GenerateAuthToken.Success} containing the api token, refresh token, origin and epoch timestamp when token expires.
@@ -28,12 +28,12 @@ export class AuthClient extends AbstractAuthClient implements IAuthClient {
    */
   public async generateAuthToken(
     controlEndpoint: string,
-    sessionToken: string,
+    token: string,
     expiresIn: ExpiresIn
   ): Promise<GenerateAuthToken.Response> {
     return await this.authClient.generateAuthToken(
       controlEndpoint,
-      sessionToken,
+      token,
       expiresIn
     );
   }

--- a/packages/client-sdk-nodejs/src/internal/auth-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/auth-client.ts
@@ -32,7 +32,7 @@ export class AuthClient {
 
   public async generateAuthToken(
     controlEndpoint: string,
-    sessionToken: string,
+    token: string,
     expiresIn: ExpiresIn
   ): Promise<GenerateAuthToken.Response> {
     const authClient = new grpcAuth.AuthClient(
@@ -41,7 +41,7 @@ export class AuthClient {
     );
 
     const request = new grpcAuth._GenerateApiTokenRequest({
-      session_token: sessionToken,
+      session_token: token,
     });
 
     if (expiresIn.doesExpire()) {

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -25,11 +25,11 @@ export class InternalWebGrpcAuthClient<
 
   public async generateAuthToken(
     controlEndpoint: string,
-    sessionToken: string,
+    token: string,
     expiresIn: ExpiresIn
   ): Promise<GenerateAuthToken.Response> {
     const request = new _GenerateApiTokenRequest();
-    request.setSessionToken(sessionToken);
+    request.setSessionToken(token);
     if (expiresIn.doesExpire()) {
       request.setExpires(new Expires().setValidForSeconds(expiresIn.seconds()));
     } else {

--- a/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
+++ b/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
@@ -19,12 +19,12 @@ export abstract class AbstractAuthClient implements IAuthClient {
 
   public async generateAuthToken(
     controlEndpoint: string,
-    sessionToken: string,
+    token: string,
     expiresIn: ExpiresIn
   ): Promise<GenerateAuthToken.Response> {
     return await this.authClient.generateAuthToken(
       controlEndpoint,
-      sessionToken,
+      token,
       expiresIn
     );
   }

--- a/packages/core/src/internal/clients/auth/IAuthClient.ts
+++ b/packages/core/src/internal/clients/auth/IAuthClient.ts
@@ -8,7 +8,7 @@ import {
 export interface IAuthClient {
   generateAuthToken(
     controlEndpoint: string,
-    sessionToken: string,
+    token: string,
     expiresIn: ExpiresIn
   ): Promise<GenerateAuthToken.Response>;
 


### PR DESCRIPTION
In the not-too-distant future we will need to support generating
auth tokens using other auth tokens.  This commit renames the
arguments in the various function signatures to just `token` so
that it won't be misnamed when we do support that.
